### PR TITLE
feat(skill-registry): index npm-package skills (node_modules/*/skills)

### DIFF
--- a/extensions/skill-registry.ts
+++ b/extensions/skill-registry.ts
@@ -74,6 +74,25 @@ function userSkillDirs(): string[] {
 	];
 }
 
+async function discoverNpmPackageSkillDirs(): Promise<string[]> {
+	const home = homedir();
+	const nodeModules = join(home, ".pi/agent/npm/node_modules");
+	if (!(await pathExists(nodeModules))) return [];
+	let entries;
+	try {
+		entries = await readdir(nodeModules, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+	const out: string[] = [];
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		const skillsDir = join(nodeModules, entry.name, "skills");
+		if (await pathExists(skillsDir)) out.push(skillsDir);
+	}
+	return out;
+}
+
 function projectSkillDirs(cwd: string): string[] {
 	return [
 		join(cwd, "skills"),
@@ -229,9 +248,11 @@ function dedupeBySkillName(entries: SkillEntry[], cwd: string): SkillEntry[] {
 }
 
 function scopeForPath(cwd: string, path: string): string {
+	const cleanPath = comparablePath(path);
+	if (cleanPath.includes(`${sep}node_modules${sep}`)) return "package";
 	const cleanCwd = comparablePath(cwd);
 	const projectPrefix = cleanCwd.endsWith(sep) ? cleanCwd : `${cleanCwd}${sep}`;
-	return comparablePath(path).startsWith(projectPrefix) ? "project" : "user";
+	return cleanPath.startsWith(projectPrefix) ? "project" : "user";
 }
 
 function markdownCell(value: string): string {
@@ -371,6 +392,7 @@ async function regenerateRegistry(
 	const existingDirs = await uniqueExistingDirs([
 		...projectSkillDirs(cwd),
 		...userSkillDirs(),
+		...(await discoverNpmPackageSkillDirs()),
 	]);
 	const files: string[] = [];
 	for (const dir of existingDirs) {
@@ -489,6 +511,7 @@ async function startSkillRegistryWatcher(
 	const dirs = await uniqueExistingDirs([
 		...projectSkillDirs(cwd),
 		...userSkillDirs(),
+		...(await discoverNpmPackageSkillDirs()),
 	]);
 	let timer: ReturnType<typeof setTimeout> | undefined;
 	const refresh = () => {

--- a/extensions/skill-registry.ts
+++ b/extensions/skill-registry.ts
@@ -87,8 +87,27 @@ async function discoverNpmPackageSkillDirs(): Promise<string[]> {
 	const out: string[] = [];
 	for (const entry of entries) {
 		if (!entry.isDirectory()) continue;
-		const skillsDir = join(nodeModules, entry.name, "skills");
-		if (await pathExists(skillsDir)) out.push(skillsDir);
+		if (entry.name.startsWith("@")) {
+			// Scoped package layout: node_modules/@scope/<pkg>/skills.
+			// The scope directory itself is never a package, so descend one level
+			// and inspect each scoped package for a skills directory.
+			let scopedEntries;
+			try {
+				scopedEntries = await readdir(join(nodeModules, entry.name), {
+					withFileTypes: true,
+				});
+			} catch {
+				continue;
+			}
+			for (const scopedEntry of scopedEntries) {
+				if (!scopedEntry.isDirectory()) continue;
+				const skillsDir = join(nodeModules, entry.name, scopedEntry.name, "skills");
+				if (await pathExists(skillsDir)) out.push(skillsDir);
+			}
+		} else {
+			const skillsDir = join(nodeModules, entry.name, "skills");
+			if (await pathExists(skillsDir)) out.push(skillsDir);
+		}
 	}
 	return out;
 }
@@ -535,6 +554,19 @@ async function startSkillRegistryWatcher(
 			activeWatchers.add(watcher);
 		} catch {
 			// Some filesystems do not support recursive watches; session_start/manual refresh still work.
+		}
+	}
+	// Also watch the npm package root (non-recursive) so newly installed or removed
+	// packages trigger discoverNpmPackageSkillDirs again via regenerateRegistry. The
+	// discovered skill directories above are captured once at start; without this root
+	// watch, a package installed mid-session would not refresh the registry.
+	const npmRoot = join(homedir(), ".pi/agent/npm/node_modules");
+	if (await pathExists(npmRoot)) {
+		try {
+			const rootWatcher = watch(npmRoot, { recursive: false }, refresh);
+			activeWatchers.add(rootWatcher);
+		} catch {
+			// Best-effort; some platforms limit watchers on large directories.
 		}
 	}
 }

--- a/extensions/skill-registry.ts
+++ b/extensions/skill-registry.ts
@@ -556,17 +556,30 @@ async function startSkillRegistryWatcher(
 			// Some filesystems do not support recursive watches; session_start/manual refresh still work.
 		}
 	}
-	// Also watch the npm package root (non-recursive) so newly installed or removed
-	// packages trigger discoverNpmPackageSkillDirs again via regenerateRegistry. The
-	// discovered skill directories above are captured once at start; without this root
-	// watch, a package installed mid-session would not refresh the registry.
+	// Also watch the npm package root and each existing scope directory (non-recursive)
+	// so newly installed or removed packages trigger discoverNpmPackageSkillDirs again
+	// via regenerateRegistry. The root watch catches new unscoped packages and brand-new
+	// scopes; each scope-directory watch catches packages added under an existing @scope,
+	// which do not appear as direct children of the npm root.
 	const npmRoot = join(homedir(), ".pi/agent/npm/node_modules");
 	if (await pathExists(npmRoot)) {
+		const watchRoots = [npmRoot];
 		try {
-			const rootWatcher = watch(npmRoot, { recursive: false }, refresh);
-			activeWatchers.add(rootWatcher);
+			for (const entry of await readdir(npmRoot, { withFileTypes: true })) {
+				if (entry.isDirectory() && entry.name.startsWith("@")) {
+					watchRoots.push(join(npmRoot, entry.name));
+				}
+			}
 		} catch {
-			// Best-effort; some platforms limit watchers on large directories.
+			// Best-effort; proceed with at least the npm root.
+		}
+		for (const root of watchRoots) {
+			try {
+				const rootWatcher = watch(root, { recursive: false }, refresh);
+				activeWatchers.add(rootWatcher);
+			} catch {
+				// Best-effort; some platforms limit watchers on large directories.
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Problem

`extensions/skill-registry.ts` scans only **loose** skill directories (`~/.pi/agent/skills`, `<cwd>/.claude/skills`, `~/.trae/skills`, …) and **misses npm-package-installed skills** — the ones living at `~/.pi/agent/npm/node_modules/*/skills/`.

These include gentle-pi's own skills (`gentle-ai-*`, `comment-writer`, `cognitive-doc-design`, `release`, `work-unit-commits`), plus `context-mode`, `pi-lens`, `pi-mcp-adapter`, `pi-subagents`, `pi-intercom` — roughly **26 skills** that pi loads into the agent's `<available_skills>` but the registry never indexes.

## Impact

Subagent delegation consumes `.atl/skill-registry.md` to discover and pass skill paths. Because npm-package skills aren't indexed, a delegated subagent can't see them — e.g. a task delegated to a subagent that needs a gentle-ai / context-mode / pi-lens skill gets `skill_resolution: none`, even though the skill is installed and available to the parent agent.

On my machine the registry went from **53 → 79** skills after this patch (26 package skills correctly indexed under a new `package` scope).

## Fix

1. **`discoverNpmPackageSkillDirs()`** — scans `~/.pi/agent/npm/node_modules/*/skills/` and returns the existing per-package skill dirs.
2. Wire it into **`regenerateRegistry`** (scan list) and **`startSkillRegistryWatcher`** (watch dirs), so adding/removing a package skill refreshes the registry.
3. **`scopeForPath`** gains a `"package"` scope for `node_modules` paths, so the registry distinguishes `project` / `user` / `package` sources.

```diff
+async function discoverNpmPackageSkillDirs(): Promise<string[]> {
+	const home = homedir();
+	const nodeModules = join(home, ".pi/agent/npm/node_modules");
+	if (!(await pathExists(nodeModules))) return [];
+	… // readdir node_modules, collect <pkg>/skills dirs that exist
+}

 const existingDirs = await uniqueExistingDirs([
 	...projectSkillDirs(cwd),
 	...userSkillDirs(),
+	...(await discoverNpmPackageSkillDirs()),
 ]);

 function scopeForPath(cwd, path) {
+	const cleanPath = comparablePath(path);
+	if (cleanPath.includes(`${sep}node_modules${sep}`)) return "package";
 	… // existing project / user logic
 }
```

## Related (separate, flagged for follow-up — NOT in this PR)

While wiring this I noticed `shouldSkipDuplicateExtensionLoad` checks `<cwd>/extensions/skill-registry.ts` for the project-local override, but pi's `discoverAndLoadExtensions` (`@earendil-works/pi-coding-agent/dist/core/extensions/loader.js`) actually loads project extensions from `<cwd>/.pi/extensions/` (`CONFIG_DIR_NAME/extensions`). So the self-skip never fires for a real project override → duplicate execution (or, if the override is placed at `<cwd>/extensions/`, the package self-skips but pi never loads it → registry disappears). That path mismatch is a separate bug; this PR leaves it untouched.

## Testing

- Patch transpiles clean (pi's tsx loader).
- Applied locally: registry regenerated with 26 package skills indexed under `package` scope; project + user skills unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic discovery of skills installed through npm packages.
  * Included discovered skills in registry updates and filesystem monitoring.
  * Correctly categorizes npm-installed skills as package-provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->