### PR TITLE
test(agents): assert per-JD-agent model profiles can diverge

### DIFF
--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 import { gzipSync } from "node:zlib";
-import { initTheme, keyHint } from "@earendil-works/pi-coding-agent";
+import { initTheme } from "@earendil-works/pi-coding-agent";
 import type {
 	ExtensionAPI,
 	ExtensionContext,
@@ -177,7 +177,6 @@ test("registered Gentle Review tools preserve result envelopes and redact collap
 	assert.deepEqual(result.details, visibleEnvelope);
 
 	const resultText = "safe result\x1b[31m\nlineage=secret body=private";
-	const expandHint = keyHint("app.tools.expand", "to expand");
 	for (const name of ["gentle_review", "gentle_review_scope", "gentle_review_capture"]) {
 		const tool = tools.get(name);
 		assert.equal(typeof tool?.renderResult, "function", `${name} must define result rendering`);
@@ -187,8 +186,9 @@ test("registered Gentle Review tools preserve result envelopes and redact collap
 			{ expanded: false, isPartial: false, isError: true },
 		]) {
 			const collapsed = renderComponent(tool.renderResult({ content: [{ type: "text", text: resultText }] }, options, lifecycleTheme, {}));
-			assert.match(cardBody(collapsed), /\d+ lines?\b/, `${name} collapsed output must contain one expand hint`);
-			assert.match(cardBody(collapsed), /\d+ lines?\b/, `${name} collapsed output must start with the hint`);
+			const collapsedBody = cardBody(collapsed);
+			assert.equal((collapsedBody.match(/\d+ lines?\b/g) ?? []).length, 1, `${name} collapsed output must contain one expand hint`);
+			assert.match(collapsedBody, /^<dim>\d+ lines?\b<\/dim>/, `${name} collapsed output must start with the hint`);
 			assert.doesNotMatch(collapsed, /safe result|lineage=secret|private/);
 		}
 		const expanded = renderComponent(tool.renderResult({ content: [{ type: "text", text: resultText }] }, { expanded: true, isPartial: false, isError: true }, lifecycleTheme, {}));

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -923,15 +923,28 @@ test("per-JD-agent model assignment keeps judge-a and judge-b profiles divergent
 		else process.env.GENTLE_PI_AGENT_HOME = previousHome;
 		rmSync(root, { recursive: true, force: true });
 	});
-	writeMarkdown(join(root, "agents", "jd-judge-a.md"), "name: jd-judge-a\n");
-	writeMarkdown(join(root, "agents", "jd-judge-b.md"), "name: jd-judge-b\n");
+	writeMarkdown(
+		join(root, "agents", "jd-judge-a.md"),
+		"---\nname: jd-judge-a\ndescription: Judgment Day judge A\n---\n\nYou are Judgment Day judge A.\n",
+	);
+	writeMarkdown(
+		join(root, "agents", "jd-judge-b.md"),
+		"---\nname: jd-judge-b\ndescription: Judgment Day judge B\n---\n\nYou are Judgment Day judge B.\n",
+	);
 	writeMarkdown(join(root, "agents", "jd-fix-agent.md"), "name: jd-fix-agent\n");
 
-	const result = applyModelConfig(root, {
+	applyModelConfig(root, {
 		"jd-judge-a": { model: "anthropic/claude-3-7-sonnet", thinking: "high" },
 		"jd-judge-b": { model: "openai/gpt-4o", thinking: "low" },
 	});
-	assert.equal(result.updated, 2, "both JD judges must be routed");
+
+	const judgeA = readFileSync(join(root, "agents", "jd-judge-a.md"), "utf8");
+	assert.match(judgeA, /^model: anthropic\/claude-3-7-sonnet$/m);
+	assert.match(judgeA, /^thinking: high$/m);
+
+	const judgeB = readFileSync(join(root, "agents", "jd-judge-b.md"), "utf8");
+	assert.match(judgeB, /^model: openai\/gpt-4o$/m);
+	assert.match(judgeB, /^thinking: low$/m);
 
 	const profiles = JSON.parse(
 		readFileSync(join(root, "subagents.json"), "utf8"),

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -914,6 +914,45 @@ test("discoverable model agents include installed Judgment Day agents", (t) => {
 	);
 });
 
+test("per-JD-agent model assignment keeps judge-a and judge-b profiles divergent", (t) => {
+	const root = mkdtempSync(join(tmpdir(), "gentle-pi-jd-diversity-"));
+	const previousHome = process.env.GENTLE_PI_AGENT_HOME;
+	process.env.GENTLE_PI_AGENT_HOME = root;
+	t.after(() => {
+		if (previousHome === undefined) delete process.env.GENTLE_PI_AGENT_HOME;
+		else process.env.GENTLE_PI_AGENT_HOME = previousHome;
+		rmSync(root, { recursive: true, force: true });
+	});
+	writeMarkdown(join(root, "agents", "jd-judge-a.md"), "name: jd-judge-a\n");
+	writeMarkdown(join(root, "agents", "jd-judge-b.md"), "name: jd-judge-b\n");
+	writeMarkdown(join(root, "agents", "jd-fix-agent.md"), "name: jd-fix-agent\n");
+
+	const result = applyModelConfig(root, {
+		"jd-judge-a": { model: "anthropic/claude-3-7-sonnet", thinking: "high" },
+		"jd-judge-b": { model: "openai/gpt-4o", thinking: "low" },
+	});
+	assert.equal(result.updated, 2, "both JD judges must be routed");
+
+	const profiles = JSON.parse(
+		readFileSync(join(root, "subagents.json"), "utf8"),
+	);
+	assert.equal(
+		profiles.model_profiles["jd-judge-a"].model,
+		"anthropic/claude-3-7-sonnet",
+	);
+	assert.equal(profiles.model_profiles["jd-judge-a"].effort, "high");
+	assert.equal(
+		profiles.model_profiles["jd-judge-b"].model,
+		"openai/gpt-4o",
+	);
+	assert.equal(profiles.model_profiles["jd-judge-b"].effort, "low");
+	assert.notEqual(
+		profiles.model_profiles["jd-judge-a"].model,
+		profiles.model_profiles["jd-judge-b"].model,
+		"judge-a and judge-b must be able to run with different models in one JD run",
+	);
+});
+
 test("model panel render does not auto-apply the Gentle theme and sanitizes agent labels", () => {
 	const lines = __testing.renderSddModelPanel(
 		{},


### PR DESCRIPTION
Closes Gentleman-Programming/gentle-ai#703

## Problem

#703 asked for per-JD-agent model assignment so `jd-judge-a` and `jd-judge-b` can run with different LLMs in the same Judgment Day run. The routing itself landed in `gentle-pi` (`CORE_MODEL_AGENT_NAMES` + `applyModelConfig` writing per-agent `model_profiles`), and discovery/ordering are covered — but no test asserts the actual diversity guarantee: that the two judges can hold **different** models in the same apply pass.

## What this adds

One unit test in `tests/gentle-ai.test.ts` following the existing installed-agents pattern:

- Creates a `GENTLE_PI_AGENT_HOME` with `jd-judge-a`, `jd-judge-b`, `jd-fix-agent` agents.
- Applies distinct model + thinking entries for both judges via `applyModelConfig`.
- Asserts both `model_profiles` entries exist with their own model/effort, and that the two models are **not equal** — the diversity guarantee the JD protocol depends on.

A literal two-LLM E2E run is not CI-feasible; this proves the per-agent divergence at the config surface the runtime reads.

## Verification

- `node --experimental-strip-types --test tests/gentle-ai.test.ts` → 8/8 pass (new test included).
- `pnpm run check:provider-contract` → passed.
- Note: `tests/runtime-harness.mjs` fails on `main` before this change too (pre-pr gate message mismatch against the installed gentle-ai binary) — unrelated to this test-only change, confirmed via stash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that separate Judgment Day agents retain distinct model and effort configurations.
  * Verified that applying settings to multiple agents updates each independently without merging or overwriting their individual model profiles.
  * Confirmed collapsed results display a single line-count hint at the start of the content.
  * Confirmed configured agents can continue using different models after settings are applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->