### PR TITLE
fix(agents): preserve parent extension selection in children

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ flowchart TD
         C2 --> C3["Apply scoped fix"]
         C3 --> V["validating"]
         V -->|Validator passes| A1
-		V -->|Fails, malformed, or out of scope| E1["escalated"]
+  V -->|Fails, malformed, or out of scope| E1["escalated"]
     end
 
     A1 --> O["Review outcome is informational"]
@@ -715,7 +715,7 @@ Gentle notices are drawn as cards: the same rounded frame as the prompt, with th
 
 The current package requires Pi 0.85.1 or newer (development tests pin 0.85.1). Use the latest Pi release; gentle-pi does not update your installed Pi automatically. Children, including any `GENTLE_PI_AGENTS_PI` override, must emit `agent_settled`: `agent_end` records a run's output but is not completion because retries or queued continuations may follow.
 
-The `subagent_*` tools and the agents card replace the third-party subagents package (remove `npm:pi-subagents-j0k3r` from your pi packages; while it is still installed the tools stay unregistered and a warning says so at startup). Agent definitions and settings are the ones you already have: markdown agents in `~/.pi/agent/agents/`, `~/.pi/agent/subagents/`, `<cwd>/.pi/agents/`, `<cwd>/.pi/subagents/` (project beats global, `subagents/` beats `agents/`), and `subagents.json` at the global and project level (`default_model`, `default_effort`, `default_mode`, `model_profiles`, `stall_timeout_ms`, `max_concurrency`, `history_max_tasks`).
+The `subagent_*` tools and the agents card replace the third-party subagents package (remove `npm:pi-subagents-j0k3r` from your pi packages; while it is still installed the tools stay unregistered and a warning says so at startup). Agent definitions and settings are the ones you already have: markdown agents in `~/.pi/agent/agents/`, `~/.pi/agent/subagents/`, `<cwd>/.pi/agents/`, `<cwd>/.pi/subagents/` (project beats global, `subagents/` beats `agents/`), and `subagents.json` at the global and project level (`default_model`, `default_effort`, `default_mode`, `model_profiles`, `stall_timeout_ms`, `max_concurrency`, `history_max_tasks`, `extensions`).
 
 Agent paths follow `GENTLE_PI_AGENT_HOME`, then `PI_CODING_AGENT_DIR`, then `~/.pi/agent` for definitions, config, history, child sessions, and transcripts. These overrides select the agent profile; they do not sandbox project or shared global resources.
 
@@ -727,6 +727,8 @@ Agent paths follow `GENTLE_PI_AGENT_HOME`, then `PI_CODING_AGENT_DIR`, then `~/.
 ```
 
 Every subagent is its own `pi --mode rpc` child process, so the terminal never runs subagent work: the host reads JSON lines, applies each one as a small delta to a bounded per-task thread, and notifies only the listeners of that task. A task-mode child's question (`ctx.ui.select`, `confirm`, `input`, `editor`) reaches you as an ordinary pi dialog; a background child's question is dismissed. Subagents have no automatic total execution timeout: a long-running child remains live while it continues emitting RPC events. A silent child still times out through the configurable `stall_timeout_ms` watchdog (default four minutes). Closing pi stops the children that are still running.
+
+`extensions` controls each child's Pi extensions: omit it to use Pi's ambient discovery, set `[]` to launch with only `--no-extensions`, or list paths to launch with `--no-extensions` and those extensions in order. A project value replaces the global value.
 
 - `subagent_list_agents`, `subagent_run` (`agent`, `task`, `label?`, `context?`, `workspace_root?`, `mode?` task or background), `subagent_status`, `subagent_result`, `subagent_list_tasks`, `subagent_reply` (one current-session reply to a live child query), `subagent_cancel`, `subagent_send_message` (steer a running child), `subagent_continue` (resume a finished task in its own session).
 - `subagent_run.workspace_root` selects an existing worktree in the session's Git clone. Validation happens before queueing; the child runs at that canonical root. Successful OS spawn registers the root in the originating parent session, including delayed queued launches, even without an active shell listener. Failed spawns do not register. `subagent_continue` retains the previous task's cwd; status and task details expose it.

--- a/extensions/gentle-agents.ts
+++ b/extensions/gentle-agents.ts
@@ -661,6 +661,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 			...(target === undefined ? {} : { onLaunch: () => { registry.register(target, "subagent:spawn"); } }),
 			model: profile.model,
 			thinking: profile.thinking,
+			extensions: config.extensions,
 			sessionDir,
 			resumeSessionPath: resume,
 			env: research ? { ...deps.env, [RESEARCH_CHILD_TOOLS_ENV]: JSON.stringify(research.agent.tools) } : deps.env,

--- a/lib/agents-config.ts
+++ b/lib/agents-config.ts
@@ -75,6 +75,7 @@ export interface AgentsConfig {
 	stallTimeoutMs: number;
 	maxConcurrency: number;
 	historyMaxTasks: number;
+	extensions?: string[];
 }
 
 export interface ProfileSources {
@@ -252,6 +253,11 @@ function parseProfiles(value: unknown): Record<string, ModelProfile> {
 	return profiles;
 }
 
+function parseExtensions(value: unknown): string[] | undefined {
+	if (!Array.isArray(value) || !value.every((path) => typeof path === "string")) return undefined;
+	return value.filter((path) => path.length > 0);
+}
+
 function mergeProfiles(base: Record<string, ModelProfile>, override: Record<string, ModelProfile>): Record<string, ModelProfile> {
 	const merged = { ...base };
 	for (const [name, profile] of Object.entries(override)) {
@@ -276,6 +282,7 @@ export function parseAgentsConfig(global: RawConfig, project: RawConfig): Agents
 		stallTimeoutMs: positiveInteger(merged.stall_timeout_ms, DEFAULT_STALL_TIMEOUT_MS),
 		maxConcurrency: positiveInteger(merged.max_concurrency, DEFAULT_MAX_CONCURRENCY),
 		historyMaxTasks: positiveInteger(merged.history_max_tasks, DEFAULT_HISTORY_MAX_TASKS),
+		extensions: parseExtensions(merged.extensions),
 	};
 }
 

--- a/lib/agents-runner.ts
+++ b/lib/agents-runner.ts
@@ -140,7 +140,7 @@ export interface TaskRequest {
 	 * Omission preserves the explicit opt-in producer API, not policy authority.
 	 */
 	canCollectResponseObservations?: () => boolean;
-	extensions: string[] | undefined;
+	extensions?: string[];
 	// This closure stays only in the parent process. Its presence creates an
 	// inherited fd, never an environment boolean or model-visible permission.
 	authorizeParentStandingReviewPermission?: (repositoryIdentity: string) => boolean;
@@ -334,9 +334,13 @@ export class AgentRunner {
 		this.store.add(task);
 		// A caller can retain and mutate its request after dispatch. Preserve only
 		// the identity selected at construction for this child launch.
-		const launchRequest = request.sddChange === undefined
+		const launchRequest = request.sddChange === undefined && request.extensions === undefined
 			? request
-			: { ...request, sddChange: { ...request.sddChange } };
+			: {
+				...request,
+				...(request.sddChange !== undefined ? { sddChange: { ...request.sddChange } } : {}),
+				...(request.extensions !== undefined ? { extensions: [...request.extensions] } : {}),
+			};
 		this.queue.push({ task, request: launchRequest });
 		queueMicrotask(() => this.pump());
 		return task;

--- a/lib/agents-runner.ts
+++ b/lib/agents-runner.ts
@@ -140,6 +140,7 @@ export interface TaskRequest {
 	 * Omission preserves the explicit opt-in producer API, not policy authority.
 	 */
 	canCollectResponseObservations?: () => boolean;
+	extensions: string[] | undefined;
 	// This closure stays only in the parent process. Its presence creates an
 	// inherited fd, never an environment boolean or model-visible permission.
 	authorizeParentStandingReviewPermission?: (repositoryIdentity: string) => boolean;
@@ -229,6 +230,10 @@ export function childArguments(request: TaskRequest): string[] {
 	if (request.resumeSessionPath) args.push("--session", request.resumeSessionPath);
 	if (request.model) args.push("--model", request.thinking ? `${formatModelRef(request.model)}:${request.thinking}` : formatModelRef(request.model));
 	else if (request.thinking) args.push("--thinking", request.thinking);
+	if (request.extensions !== undefined) {
+		args.push("--no-extensions");
+		for (const extension of request.extensions) if (extension.length > 0) args.push("--extension", extension);
+	}
 	const tools = request.agent.tools.length > 0 ? [...new Set([...request.agent.tools, PARENT_NOTIFICATION_TOOL])] : DEFAULT_TOOLS;
 	if (tools.length > 0) args.push("--tools", tools.join(","));
 	if (request.agent.instructions.length > 0) args.push("--append-system-prompt", request.agent.instructions);

--- a/tests/agents-config.test.ts
+++ b/tests/agents-config.test.ts
@@ -131,6 +131,14 @@ test("parseAgentsConfig applies defaults, validates values, and silently ignores
 	assert.equal(parseAgentsConfig({ default_mode: "background" }, undefined).defaultMode, AGENT_MODE.BACKGROUND);
 });
 
+test("parseAgentsConfig preserves extensions' absent, isolated, and ordered states across scopes", () => {
+	assert.equal(parseAgentsConfig(undefined, undefined).extensions, undefined);
+	assert.deepEqual(parseAgentsConfig({ extensions: ["/global-a", "/global-b"] }, undefined).extensions, ["/global-a", "/global-b"]);
+	assert.deepEqual(parseAgentsConfig({ extensions: ["/global"] }, { extensions: [] }).extensions, []);
+	assert.equal(parseAgentsConfig({ extensions: ["/global"] }, { extensions: ["/project", 1] }).extensions, undefined);
+	assert.deepEqual(parseAgentsConfig(undefined, { extensions: ["", "/project"] }).extensions, ["/project"]);
+});
+
 test("resolveAgentProfile prefers the profile, then the definition, then the defaults", () => {
 	const config = parseAgentsConfig({ default_model: "openai-codex/gpt-6-astra", default_effort: "medium", model_profiles: { "gentle-ai-explore": { effort: "high" } } }, undefined);
 	const explore = parseAgentDefinition(EXPLORER, "/x/explore.md", "global");

--- a/tests/agents-runner.test.ts
+++ b/tests/agents-runner.test.ts
@@ -249,6 +249,26 @@ test("launch registration waits for actual spawn, including queued launches, and
 	assert.deepEqual(cwds, ["/child", "/queued", "/missing", "/throws"]);
 });
 
+test("a queued launch keeps the extension selection captured at dispatch", async () => {
+	const args: string[][] = [];
+	const store = new TaskStore();
+	const runner = new AgentRunner(store, { maxConcurrency: 1, stallTimeoutMs: 1000 }, {
+		spawn: (_command, launchArgs) => {
+			args.push(launchArgs);
+			return fakeChild().child;
+		},
+		now: () => 1000, schedule: () => () => {}, pi: { command: "pi", args: [] },
+	}, { askUser: async () => ({ cancelled: true }) });
+	const selected = ["/extensions/first.js"];
+	const task = runner.run(request({ extensions: selected }));
+	selected.push("/extensions/mutated-after-dispatch.js");
+	await tick();
+	assert.ok(args[0]?.includes("/extensions/first.js"), "the dispatched selection reaches the child launch");
+	assert.ok(!args[0]?.includes("/extensions/mutated-after-dispatch.js"), "post-dispatch array mutation must not leak into the launch");
+	runner.cancel(task.id);
+	await tick();
+});
+
 test("runner captures resolved model and effort, retaining omitted launch values", async () => {
 	for (const scenario of [
 		{ state: { model: { provider: "anthropic", id: "resolved-model" }, thinkingLevel: "off" }, model: "anthropic/resolved-model", thinking: "off" },

--- a/tests/agents-runner.test.ts
+++ b/tests/agents-runner.test.ts
@@ -363,6 +363,9 @@ test("childArguments builds an rpc launch with model, thinking, tools, session d
 	const resumed = childArguments(request({ resumeSessionPath: "/sessions/old.jsonl", model: undefined, thinking: undefined, agent: { ...explorer, tools: [] } }));
 	assert.equal(resumed[resumed.indexOf("--session") + 1], "/sessions/old.jsonl");
 	assert.ok(!resumed.includes("--model") && !resumed.includes("--tools"));
+	const extensions = childArguments(request({ extensions: ["/extensions/first.js", "", "/extensions/second.js"] }));
+	assert.deepEqual(extensions.slice(extensions.indexOf("--no-extensions"), extensions.indexOf("--tools")), ["--no-extensions", "--extension", "/extensions/first.js", "--extension", "/extensions/second.js"]);
+	assert.deepEqual(childArguments(request({ extensions: [] })).filter((arg) => arg === "--no-extensions" || arg === "--extension"), ["--no-extensions"]);
 });
 
 test("childArguments grants every child the notification-only parent message tool", () => {

--- a/tests/gentle-agents.test.ts
+++ b/tests/gentle-agents.test.ts
@@ -57,7 +57,7 @@ mkdirSync(join(home, ".pi", "agent", "agents"), { recursive: true });
 mkdirSync(cwd, { recursive: true });
 mkdirSync(nonGitCwd, { recursive: true });
 writeFileSync(join(home, ".pi", "agent", "agents", "explore.md"), "---\ndescription: maps things\nmodel: openai-codex/gpt-5.6-terra\nthinking: high\ntools: [read, grep]\n---\nYou map things.");
-writeFileSync(join(home, ".pi", "agent", "subagents.json"), JSON.stringify({ max_concurrency: 2, model_profiles: { explore: { effort: "low" } } }));
+writeFileSync(join(home, ".pi", "agent", "subagents.json"), JSON.stringify({ max_concurrency: 2, extensions: ["/global/extension.js"], model_profiles: { explore: { effort: "low" } } }));
 
 function fakePi() {
 	const handlers = new Map<string, Handler[]>();
@@ -883,7 +883,7 @@ test("default Node spawn adapter distinguishes IPC-only and permission-capable c
 		children[2]!.emit({ type: "agent_settled" });
 		await permission.result;
 
-		const args = ["--host-flag", "--mode", "rpc", "--session-dir", join(home, ".pi", "agent", "gentle-agents", "sessions"), "--model", "openai-codex/gpt-5.6-terra:low", "--tools", "read,grep,subagent_parent_message", "--append-system-prompt", "You map things."];
+		const args = ["--host-flag", "--mode", "rpc", "--session-dir", join(home, ".pi", "agent", "gentle-agents", "sessions"), "--model", "openai-codex/gpt-5.6-terra:low", "--no-extensions", "--extension", "/global/extension.js", "--tools", "read,grep,subagent_parent_message", "--append-system-prompt", "You map things."];
 		assert.equal(captured.length, 3, "the extension reaches Node's spawn boundary for IPC-only and permission-channel launches");
 		for (const [index, fixture] of ["task", "background", "permission"].entries()) {
 			const permissionChannel = index === 2;
@@ -1222,6 +1222,7 @@ test("subagent_list_agents and subagent_run in task mode launch a child with the
 	const [args] = harness.spawned;
 	assert.equal(args[args.indexOf("--model") + 1], "openai-codex/gpt-5.6-terra:low", "the profile effort overrides the definition");
 	assert.equal(args[args.indexOf("--tools") + 1], "read,grep,subagent_parent_message");
+	assert.deepEqual(args.slice(args.indexOf("--no-extensions"), args.indexOf("--tools")), ["--no-extensions", "--extension", "/global/extension.js"]);
 	await tick();
 	assert.match(String(harness.children[0].written[1].message), /Map lib\/ and report every module\.\n\n## Context\nFocus on agents-\*\.ts/);
 	assert.match(widget()![0], /^╭─ ❀ Agents · 1 active ─+ \d+s ╮$/);


### PR DESCRIPTION
## Linked Issue

Fixes Gentleman-Programming/gentle-ai#602
Addresses #593

## PR Type

- [x] Bug fix

(Label `type:bug` requested from a maintainer because external contributors cannot add labels.)

## Summary

- Adds a generic `extensions` tri-state to Gentle Agents configuration instead of stamping Engram-specific paths into packaged agent assets.
- Preserves ambient Pi extension discovery when omitted, isolates children with `extensions: []`, and forwards an explicit ordered extension list when configured.
- Lets project configuration replace the global extension selection, including an explicit empty list.

## Changes

| File | Change |
|------|--------|
| `lib/agents-config.ts` | Parses the optional validated `extensions` list with project precedence. |
| `lib/agents-runner.ts` | Emits `--no-extensions` and ordered `--extension <path>` arguments for explicit selections. |
| `extensions/gentle-agents.ts` | Propagates configuration into each child launch request. |
| `tests/agents-config.test.ts` | Covers absent, empty, ordered, malformed, and project-override states. |
| `tests/agents-runner.test.ts` | Pins exact child argument behavior. |
| `tests/gentle-agents.test.ts` | Verifies config-to-spawn propagation. |
| `README.md` | Documents the three configuration states. |

## Verification

- [x] Focused tests: 37 passed, 0 failed.
- [x] Repository tests excluding the independently reproduced `tests/rdd-status-line.test.ts` baseline cancellation: 1522 passed, 0 failed, 0 cancelled, 1 skipped.
- [x] `tests/rdd-status-line.test.ts` reproduces the same 7-pass/10-cancel timeout behavior on clean `origin/main`, so it is not candidate-caused.
- [x] Provider contract check passed.
- [x] Runtime harness passed.
- [x] Runtime module consistency check passed.
- [x] Package verification passed: 165 files and 68 byte-pinned artifacts.
- [x] Native four-lens review approved and acknowledged (`review-b9ec33231fbf83c6`); malformed-config observations were informational and match the deliberate fail-open compatibility contract.

## Contributor Checklist

- [x] Linked approved umbrella issue (`Gentleman-Programming/gentle-ai#602`).
- [x] Exactly one PR type selected (`type:bug` label requested from maintainer).
- [x] No shell scripts modified.
- [x] Documentation updated for the new configuration behavior.
- [x] Conventional commit format; no `Co-Authored-By` trailers.
- [x] AI assistance declared: investigation, implementation, verification, and review were AI-assisted under human direction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration for controlling child-agent extension discovery.
  * Supports ambient discovery, disabling extensions, or explicitly loading selected extension paths.
  * Project-level settings override global settings.
  * Configured extensions are passed to child-agent launches.

* **Documentation**
  * Documented extension configuration behavior and added it to the available subagent settings.

* **Tests**
  * Added coverage for extension parsing, scope overrides, empty entries, and child-agent launch arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->