### PR TITLE
feat(gentle-shell): *** Extension for adding cross-session prompt history search

### DIFF
--- a/extensions/history/atomic-write.ts
+++ b/extensions/history/atomic-write.ts
@@ -13,17 +13,26 @@ import fs from "node:fs";
  * No fsync: both consumers treat lost writes as derived cache (a lost index
  * rebuilds on the next open; a lost tombstone resurfaces a prompt the user
  * can re-delete), so the per-write fsync cost is not justified — the crash
- * window is documented, not fixed. Orphaned `.tmp` files are overwritten by
- * the next write and are harmless.
+ * window is documented, not fixed. The staging name is unique per write
+ * (`.tmp-<pid>-<ts>`, the same convention as the store.ts writers): the
+ * state dir is shared across concurrent pi instances, so a fixed
+ * `${filePath}.tmp` would let two writers clobber the same staging file
+ * (torn target JSON, spurious rename failures). A failed write unlinks its
+ * staging file, so orphaned `.tmp` files do not accumulate.
  */
 export function writeJsonAtomic(filePath: string, value: unknown): boolean {
-  const tmpPath = `${filePath}.tmp`;
+  const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
   try {
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     fs.writeFileSync(tmpPath, JSON.stringify(value), "utf8");
     fs.renameSync(tmpPath, filePath);
     return true;
   } catch {
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      // staging file never created or already renamed
+    }
     return false;
   }
 }

--- a/extensions/history/atomic-write.ts
+++ b/extensions/history/atomic-write.ts
@@ -1,0 +1,29 @@
+import path from "node:path";
+// SPDX-FileCopyrightText: 2026 ExoPro. Inspired by @jasonish/pi-prompt-history
+// SPDX-License-Identifier: MIT
+
+import fs from "node:fs";
+
+/**
+ * Shared atomic JSON writer (design §D3): serialize to a `.tmp` file in the
+ * SAME directory as the target, then renameSync it into place — a same-dir
+ * rename is atomic on POSIX/APFS, so readers see the old or the new file,
+ * never a partial write. Any error returns false and never throws.
+ *
+ * No fsync: both consumers treat lost writes as derived cache (a lost index
+ * rebuilds on the next open; a lost tombstone resurfaces a prompt the user
+ * can re-delete), so the per-write fsync cost is not justified — the crash
+ * window is documented, not fixed. Orphaned `.tmp` files are overwritten by
+ * the next write and are harmless.
+ */
+export function writeJsonAtomic(filePath: string, value: unknown): boolean {
+  const tmpPath = `${filePath}.tmp`;
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(tmpPath, JSON.stringify(value), "utf8");
+    fs.renameSync(tmpPath, filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/extensions/history/hide-prompts.ts
+++ b/extensions/history/hide-prompts.ts
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 ExoPro. Inspired by @jasonish/pi-prompt-history
+// SPDX-License-Identifier: MIT
+
+import fs from "node:fs";
+import path from "node:path";
+import { writeJsonAtomic } from "./atomic-write.ts";
+import { promptDedupKey } from "./selector-helpers.ts";
+
+/** Name of the tombstone file inside the injected state dir (spec C4). */
+const HIDE_FILE_NAME = "hidden.json";
+
+/**
+ * Result of one tombstone write (spec C4): `written` on a successful atomic
+ * write, or an error object carrying a short, toast-suitable reason. Never
+ * throws.
+ */
+export type HideResult =
+  | { status: "written" }
+  | { status: "error"; message: string };
+
+/**
+ * Load the tombstone key set from `stateDir/hidden.json` — the READ half of
+ * the hide-file contract (spec C4). Fail-open: a missing, unreadable,
+ * corrupt, or wrong-shaped file is an EMPTY set and the call never throws;
+ * a corrupt file is rewritten clean by the next hide (the WRITE half,
+ * `hidePrompt`, lands in WU4). Keys are `promptDedupKey` strings written by
+ * `hidePrompt`; foreign values are ignored, never trusted.
+ */
+export function loadHiddenPrompts(stateDir: string): Set<string> {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(path.join(stateDir, HIDE_FILE_NAME), "utf8");
+  } catch {
+    return new Set<string>(); // missing or unreadable → empty tombstones
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return new Set<string>(); // corrupt bytes → fail-open empty
+  }
+  const keys = new Set<string>();
+  if (!Array.isArray(parsed)) return keys; // wrong shape → fail-open empty
+  for (const item of parsed) {
+    if (typeof item === "string" && item !== "") keys.add(item);
+  }
+  return keys;
+}
+
+/**
+ * Write the tombstone key for `text` into `stateDir/hidden.json` — the
+ * WRITE half of the hide-file contract (spec C4). The key is the shared
+ * `promptDedupKey` (byte-match normative with the merge filter — never a
+ * re-implementation); the set compacts on write and persists as a SORTED
+ * array via the shared atomic tmp+rename writer. Fail-open both ways: a
+ * corrupt or missing file reads as empty (this clean rewrite IS the
+ * recovery — the corrupt contents are untrustworthy by definition) and any
+ * write failure returns an error object for the delete-flow toast; the
+ * call never throws.
+ */
+export function hidePrompt(stateDir: string, text: string): HideResult {
+  const keys = loadHiddenPrompts(stateDir);
+  keys.add(promptDedupKey(text));
+  const written = writeJsonAtomic(
+    path.join(stateDir, HIDE_FILE_NAME),
+    [...keys].sort(),
+  );
+  return written
+    ? { status: "written" }
+    : {
+        status: "error",
+        message: "Could not write the hide file; the prompt may reappear.",
+      };
+}

--- a/extensions/history/index.ts
+++ b/extensions/history/index.ts
@@ -371,7 +371,7 @@ class PromptHistorySelector extends Container implements Focusable {
       new FixedRowText(
         theme.fg(
           "dim",
-          "↑↓ move • PgUp/PgDn page • tab scope • ctrl+shift+↑/↓ preview • ctrl+shift+backspace delete • esc cancel",
+          "↑↓ move • PgUp/PgDn page • tab scope • enter select and quit • ctrl+shift+↑/↓ preview • ctrl+shift+backspace delete • esc cancel",
         ),
         true /* centered */,
       ),

--- a/extensions/history/index.ts
+++ b/extensions/history/index.ts
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2026 ExoPro. Inspired by @jasonish/pi-prompt-history
+// SPDX-FileCopyrightText: 2026 ExoPro. Inspired by @jasonish/pi-prompt-history
 // SPDX-License-Identifier: MIT
 
 import { join } from "node:path";

--- a/extensions/history/index.ts
+++ b/extensions/history/index.ts
@@ -1,0 +1,1053 @@
+//SPDX-FileCopyrightText: 2026 ExoPro. Inspired by @jasonish/pi-prompt-history
+// SPDX-License-Identifier: MIT
+
+import { join } from "node:path";
+import { homedir } from "node:os";
+import fs from "node:fs";
+import {
+  DynamicBorder,
+  type ExtensionAPI,
+  type ShortcutContext,
+  type Theme,
+} from "@earendil-works/pi-coding-agent";
+import {
+  appendSessionCapture,
+  bootstrapProjectSeed,
+  deleteFromGlobal,
+  deleteFromProject,
+  drainGlobal,
+  drainProject,
+  gcProjectDir,
+  migrateLegacyStores,
+  openSessionWriter,
+  type SessionWriterState,
+} from "./store.ts";
+import { ensureRegistryEntry } from "./store.ts";
+import { randomUUID } from "node:crypto";
+import { hidePrompt } from "./hide-prompts.ts";
+import {
+  buildPromptRecords,
+  filterPrompts,
+  type PromptEntry,
+  clampPreviewOffset,
+  clampSelectedIndex,
+  deletionActionsFor,
+  dedupePromptEntries,
+  getVisiblePromptRecords,
+  initialLoadedCount,
+  loadedCountAfterDelete,
+  loadedCountForQuery,
+  loadedCountForTarget,
+  moveSelectedIndex,
+  nextLoadedCount,
+  pageSelectedIndex,
+  shouldGrowWindow,
+  withExpandedHistoryGlobals,
+  type PiHistoryGlobals,
+  type PromptRecord,
+} from "./selector-helpers.ts";
+import {
+  Container,
+  type Focusable,
+  getKeybindings,
+  Input,
+  matchesKey,
+  Text,
+  type TUI,
+  type TuiMouseEvent,
+  truncateToWidth,
+} from "@earendil-works/pi-tui";
+
+const SHORTCUT = "ctrl+shift+r";
+const MAX_VISIBLE = 10;
+const PREVIEW_ROWS = 10;
+// Lazy windowing (design §D3; user-tuned 2026-09-08). PRELOAD_BUFFER=2
+// fires growth as the cursor enters the final 2 loaded rows; BATCH_SIZE=10
+// loads exactly one viewport per growth; INITIAL_BATCH=10 paints one
+// viewport at open. PRELOAD_BUFFER <= MAX_VISIBLE keeps a jump within one
+// viewport covered by the catch-up loop; review all three together.
+const INITIAL_BATCH = 10;
+const BATCH_SIZE = 10;
+const PRELOAD_BUFFER = 3;
+// Wheel regions over the fixed 30-row overlay geometry (design §D6): the
+// list container renders at rows 5-14 and the preview container at rows
+// 17-26; every other row is a consumed no-op.
+const LIST_WHEEL_Y_FIRST = 5;
+const LIST_WHEEL_Y_LAST = 14;
+const PREVIEW_WHEEL_Y_FIRST = 17;
+const PREVIEW_WHEEL_Y_LAST = 26;
+
+    // v2 multi-concurrency store root (design: tmp/multi-concurrency-design.md).
+    const PI_HISTORY_ROOT = join(
+      homedir(),
+      ".pi",
+      "agent",
+      "history",
+    );
+    const AGENT_DIR = join(homedir(), ".pi", "agent");
+    const CURRENT_CWD = process.cwd();
+    // Instance identity: one exclusive capture file per pi process.
+    const INSTANCE_ID = randomUUID();
+
+// State dir for the session index and the tombstone file (spec C2/C4,
+// design §D5). Derived state only — deleting the directory restores cold
+// start and unhides every prompt; transcripts and the editor store are
+// never written here.
+// Tombstone state dir: the store root itself (user-directed FINAL):
+// ~/.pi/agent/history/hidden.json — one directory for everything.
+const PI_HISTORY_NAV_STATE_DIR = join(
+  homedir(),
+  ".pi",
+  "agent",
+  "history",
+);
+
+// Sessions root for the one-level transcript scan (spec C1, design §D5):
+// ~/.pi/agent/sessions/. Read-only by invariant — transcripts are never
+// written by this extension.
+const SESSIONS_ROOT = join(homedir(), ".pi", "agent", "sessions");
+
+/** Width of the "→ " / "  " prefix on each entry line. */
+const ENTRY_PREFIX_WIDTH = 2;
+
+// ---------------------------------------------------------------------------
+// Sanitization
+// ---------------------------------------------------------------------------
+
+/**
+ * Replace control characters with visible escape notation so the terminal
+ * renders them as text instead of interpreting them as commands.
+ * Preserves \n (newlines) and \t (tabs).
+ */
+function sanitizeForDisplay(text: string): string {
+  let out = "";
+  for (let i = 0; i < text.length; i++) {
+    const cp = text.codePointAt(i)!;
+    if (cp === 0x0a) {
+      out += "\n";
+    } else if (cp === 0x09) {
+      out += "\t";
+    } else if (cp < 0x20 || cp === 0x7f) {
+      out += "\\x" + cp.toString(16).padStart(2, "0");
+    } else if (cp >= 0x80 && cp < 0xa0) {
+      out += "\\x" + cp.toString(16).padStart(2, "0");
+    } else {
+      out += text[i];
+    }
+    if (cp > 0xffff) i++; // skip low surrogate of astral pair
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Keybinding lookup returned by getKeybindings(). */
+interface Keybindings {
+  matches(data: string, action: string): boolean;
+}
+
+type InputMatcher = (data: string, kb: Keybindings) => boolean;
+type InputHandler = () => void;
+
+interface DispatchEntry {
+  match: InputMatcher;
+  handler: InputHandler;
+}
+
+/** Notification sink for selector feedback; an absent callback drops notifications. */
+type SelectorNotify = (message: string, level: "error" | "warning" | "info") => void;
+
+/** Single rendered row; always occupies exactly one terminal row. */
+class FixedRowText {
+  constructor(
+    private text: string = "",
+    private readonly centered = false,
+  ) {}
+
+  /** Replace the row content in place; padding contract comes from render(). */
+  setText(next: string): void {
+    this.text = next;
+  }
+
+  invalidate(): void {}
+
+  render(width: number): string[] {
+    if (width <= 0) return [" "] as string[];
+    if (this.text.length === 0) {
+      // Use a space so the terminal always renders this as a visible row
+      // and differential rendering correctly detects it as a changed line.
+      return [" ".repeat(width)] as string[];
+    }
+    const rendered = this.centered
+      ? (() => {
+          // Truncate first so an overlong help row can never exceed width,
+          // then center the truncated copy (design §C hardening).
+          const truncated = truncateToWidth(this.text, width, "…");
+          const visible = truncated.replace(/\x1b\[[0-9;]*m/g, "");
+          const pad = Math.max(0, Math.floor((width - visible.length) / 2));
+          return " ".repeat(pad) + truncated;
+        })()
+      : truncateToWidth(this.text, width, "…");
+    // Pad to full terminal width so the overlay fully overwrites
+    // whatever is beneath it and leaves no ghost characters on dismiss.
+    return [rendered + " ".repeat(Math.max(0, width - rendered.length))];
+  }
+}
+
+/** Word-wrap plain text so each line fits within maxWidth characters. */
+function wordWrapText(text: string, maxWidth: number): string[] {
+  if (maxWidth <= 0) return [text || " "];
+  const paragraphs = text.split("\n");
+  const result: string[] = [];
+  for (const para of paragraphs) {
+    if (para.length === 0) {
+      result.push("");
+      continue;
+    }
+    let remaining = para;
+    while (remaining.length > 0) {
+      if (remaining.length <= maxWidth) {
+        result.push(remaining);
+        break;
+      }
+      const breakAt = remaining.lastIndexOf(" ", maxWidth);
+      if (breakAt <= 0) {
+        result.push(remaining.substring(0, maxWidth));
+        remaining = remaining.substring(maxWidth);
+      } else {
+        result.push(remaining.substring(0, breakAt));
+        remaining = remaining.substring(breakAt + 1);
+      }
+    }
+  }
+  return result.length > 0 ? result : [""];
+}
+
+// ---------------------------------------------------------------------------
+// TUI Selector
+// ---------------------------------------------------------------------------
+
+class PromptHistorySelector extends Container implements Focusable {
+  private readonly searchInput: Input;
+  private readonly previewContainer: Container;
+  private readonly listContainer: Container;
+  private readonly headerRow: FixedRowText;
+  private readonly previewLabelRow: FixedRowText;
+  private records: PromptRecord[];
+  private readonly theme: Theme;
+  private readonly tui: TUI;
+  private readonly onSelect: (record: PromptRecord) => void;
+  private readonly onCancel: () => void;
+  private filteredRecords: PromptRecord[] = [];
+  private selectedIndex = 0;
+  /** Number of records loaded (newest-first) from the top of `records`. */
+  private loadedCount = 0;
+  /** Active scope (design v2): project (default) or global. */
+  private scope: "project" | "global" = "project";
+  /** Last render width, used for entry truncation. */
+  private lastWidth = 800;
+  /** Word-wrapped lines of the currently selected prompt. */
+  private wrappedPreviewLines: string[] = [];
+  /** Scroll offset into wrappedPreviewLines for the preview viewport. */
+  private previewScrollOffset = 0;
+  /**
+   * Transient indexing progress (spec C6, design §D7). Status text ONLY:
+   * records, filteredRecords, and every counter stay untouched while the
+   * overlay is open. Declaration-initialized, so the constructor child
+   * sequence (12 children) is unchanged.
+   */
+  private indexProgress: { processed: number; total: number } | null = null;
+
+  /** Dispatch table: first match wins, fallthrough last. */
+  private readonly dispatch: readonly DispatchEntry[] = [
+    {
+      match: (_d, kb) => kb.matches(_d, "tui.select.up"),
+      handler: () => this.moveUp(),
+    },
+    {
+      match: (_d, kb) => kb.matches(_d, "tui.select.down"),
+      handler: () => this.moveDown(),
+    },
+    {
+      match: (_d, kb) => kb.matches(_d, "tui.select.pageUp"),
+      handler: () => this.pageListUp(),
+    },
+    {
+      match: (_d, kb) => kb.matches(_d, "tui.select.pageDown"),
+      handler: () => this.pageListDown(),
+    },
+    {
+      match: (d, kb) => d === "\r" || kb.matches(d, "tui.select.confirm"),
+      handler: () => this.selectCurrent(),
+    },
+    { match: (d, _kb) => d === "\t", handler: () => this.toggleScope() },
+    {
+      match: (_d, kb) => kb.matches(_d, "tui.select.cancel"),
+      handler: () => this.onCancel(),
+    },
+    {
+      match: (d, _kb) => matchesKey(d, "home"),
+      handler: () => this.jumpToFirst(),
+    },
+    {
+      match: (d, _kb) => matchesKey(d, "end"),
+      handler: () => this.jumpToLast(),
+    },
+    {
+      match: (d, _kb) => matchesKey(d, "ctrl+shift+backspace"),
+      handler: () => this.deleteCurrent(),
+    },
+    {
+      match: (d, _kb) => matchesKey(d, "ctrl+shift+up"),
+      handler: () => this.previewPageUp(),
+    },
+    {
+      match: (d, _kb) => matchesKey(d, "ctrl+shift+down"),
+      handler: () => this.previewPageDown(),
+    },
+  ];
+
+  private _focused = false;
+  get focused(): boolean {
+    return this._focused;
+  }
+  set focused(value: boolean) {
+    this._focused = value;
+    this.searchInput.focused = value;
+  }
+
+  constructor(
+    tui: TUI,
+    theme: Theme,
+    records: PromptRecord[],
+    onSelect: (record: PromptRecord) => void,
+    onCancel: () => void,
+    private readonly onNotify?: SelectorNotify,
+  ) {
+    super();
+
+    this.tui = tui;
+    this.theme = theme;
+    this.records = records;
+    this.loadedCount = initialLoadedCount(records.length, INITIAL_BATCH);
+    this.onSelect = onSelect;
+    this.onCancel = onCancel;
+
+    // ── Search panel (top) ──
+    this.addChild(new DynamicBorder((s: string) => theme.fg("accent", s)));
+    this.headerRow = new FixedRowText(
+      theme.fg("accent", theme.bold(" History Search ")),
+    );
+    this.addChild(this.headerRow);
+    this.addChild(
+      new Text(
+        theme.fg("dim", "Type to filter (multi-word AND substring, case-insensitive)"),
+        0,
+        0,
+      ),
+    );
+    this.searchInput = new Input();
+    this.searchInput.onSubmit = () => this.selectCurrent();
+    this.searchInput.onEscape = () => this.onCancel();
+    this.addChild(this.searchInput);
+    this.addChild(new DynamicBorder((s: string) => theme.fg("dim", s)));
+
+    this.listContainer = new Container();
+    this.addChild(this.listContainer);
+
+    // ── Preview panel (bottom) ──
+    this.addChild(new DynamicBorder((s: string) => theme.fg("accent", s)));
+    this.previewLabelRow = new FixedRowText(
+      theme.fg("accent", theme.bold(" Preview ")),
+    );
+    this.addChild(this.previewLabelRow);
+    this.previewContainer = new Container();
+    this.addChild(this.previewContainer);
+
+    this.addChild(new DynamicBorder((s: string) => theme.fg("dim", s)));
+    this.addChild(
+      new FixedRowText(
+        theme.fg(
+          "dim",
+          "↑↓ move • PgUp/PgDn page • tab scope • ctrl+shift+↑/↓ preview • ctrl+shift+backspace delete • esc cancel",
+        ),
+        true /* centered */,
+      ),
+    );
+    this.addChild(new DynamicBorder((s: string) => theme.fg("accent", s)));
+
+    this.applyFilter("");
+  }
+
+  // -- Filtering & list building ------------------------------------------
+
+  private applyFilter(query: string): void {
+    // AC-L2-3r (user-directed 2026-09-08): a non-empty query implies
+    // full-snapshot visibility — one-shot and idempotent, never a batch —
+    // so per-keypress incremental loads remain impossible (C2).
+    this.loadedCount = loadedCountForQuery(
+      this.loadedCount,
+      this.records.length,
+      query,
+    );
+    this.filteredRecords = filterPrompts(
+      this.records.slice(0, this.loadedCount),
+      query,
+    );
+    this.selectedIndex = clampSelectedIndex(
+      this.selectedIndex,
+      this.filteredRecords.length,
+    );
+    this.previewScrollOffset = 0;
+    this.rebuildList();
+    this.rebuildPreview();
+  }
+
+  private rebuildList(): void {
+    this.rebuildListWithWidth(this.lastWidth);
+  }
+
+  /** Rebuild list rows: header counter + entries. Always MAX_VISIBLE rows. */
+  private rebuildListWithWidth(width: number): void {
+    const count = this.filteredRecords.length;
+    const position = count === 0 ? 0 : this.selectedIndex + 1;
+    this.headerRow.setText(
+      this.theme.fg("accent", this.theme.bold(" History Search ")) +
+        this.theme.fg("dim", ` · ${position} of ${count} `) +
+        this.theme.fg(
+          "dim",
+          ` · loaded ${this.loadedCount} of ${this.records.length} `,
+        ) +
+        // Right-aligned scope radio: pad from plain-text lengths so the
+        // radio ends flush at the header's last column at any width.
+        (() => {
+          const scopeRadio =
+            this.scope === "project"
+              ? "◉ Current project | ○ All projects"
+              : "○ Current project | ◉ All projects";
+          const leftWidth =
+            " History Search ".length +
+            ` · ${position} of ${count} `.length +
+            ` · loaded ${this.loadedCount} of ${this.records.length} `.length;
+          return (
+            " ".repeat(Math.max(1, width - leftWidth - scopeRadio.length)) +
+            this.theme.fg("dim", scopeRadio)
+          );
+        })(),
+    );
+    this.listContainer.clear();
+
+    if (count === 0) {
+      this.listContainer.addChild(
+        new FixedRowText(this.theme.fg("warning", "No matching prompts")),
+      );
+      for (let i = 1; i < MAX_VISIBLE; i++) {
+        this.listContainer.addChild(new FixedRowText());
+      }
+      return;
+    }
+
+    const entryMax = Math.floor(width * 0.95) - ENTRY_PREFIX_WIDTH;
+
+    const visible = getVisiblePromptRecords(
+      this.filteredRecords,
+      this.selectedIndex,
+      MAX_VISIBLE,
+    );
+
+    for (const { record, isSelected } of visible) {
+      const prefix = isSelected ? "→ " : "  ";
+      const color = isSelected ? "accent" : "text";
+      const compacted = sanitizeForDisplay(record.text)
+        .replace(/\s+/g, " ")
+        .trim();
+      const truncated = truncateToWidth(compacted, entryMax, "…");
+      const line = prefix + this.theme.fg(color, truncated);
+      this.listContainer.addChild(new FixedRowText(line));
+    }
+
+    for (let i = visible.length; i < MAX_VISIBLE; i++) {
+      this.listContainer.addChild(new FixedRowText());
+    }
+  }
+
+  /**
+   * Rebuild preview: word-wrap the full selected prompt text and show
+   * a PREVIEW_ROWS-tall viewport starting at previewScrollOffset.
+   * Content starts immediately below the "Preview" label (no top padding).
+   * PgUp/PgDn scroll through the wrapped lines.
+   */
+  private rebuildPreviewWithWidth(width: number): void {
+    this.previewContainer.clear();
+
+    const wrapWidth = Math.max(1, width - 2);
+    const selected = this.filteredRecords[this.selectedIndex];
+    if (selected) {
+      const safeText = sanitizeForDisplay(selected.text);
+      this.wrappedPreviewLines = wordWrapText(safeText, wrapWidth);
+      this.previewScrollOffset = clampPreviewOffset(
+        this.previewScrollOffset,
+        this.wrappedPreviewLines.length,
+        PREVIEW_ROWS,
+      );
+    } else {
+      this.wrappedPreviewLines = [];
+      this.previewScrollOffset = 0;
+    }
+
+    // P1-3 indicator: fresh wrap is known here — one update site covers all
+    // paths; the label appends the 1-based range only when content overflows.
+    this.previewLabelRow.setText(this.previewLabelRowText());
+
+    for (let i = 0; i < PREVIEW_ROWS; i++) {
+      const lineIdx = this.previewScrollOffset + i;
+      if (lineIdx < this.wrappedPreviewLines.length) {
+        // Pad the plain text to wrapWidth so FixedRowText.render()
+        // never truncates — the visible width is always ≤ width-2.
+        const raw = this.wrappedPreviewLines[lineIdx];
+        const padded = raw + " ".repeat(Math.max(0, wrapWidth - raw.length));
+        this.previewContainer.addChild(
+          new FixedRowText(this.theme.fg("text", padded)),
+        );
+      } else {
+        this.previewContainer.addChild(new FixedRowText());
+      }
+    }
+  }
+
+  /** " Preview " label; appends the 1-based visible range only on overflow. */
+  private previewLabelRowText(): string {
+    const total = this.wrappedPreviewLines.length;
+    if (total <= PREVIEW_ROWS) {
+      return this.theme.fg("accent", this.theme.bold(" Preview "));
+    }
+    const start = this.previewScrollOffset + 1;
+    const end = Math.min(this.previewScrollOffset + PREVIEW_ROWS, total);
+    return this.theme.fg(
+      "accent",
+      this.theme.bold(` Preview — ${start}–${end}/${total} `),
+    );
+  }
+
+  private rebuildPreview(): void {
+    this.rebuildPreviewWithWidth(this.lastWidth);
+  }
+
+  /**
+   * Transient indexing suffix update (spec C6, design §D7): clears at
+   * processed >= total and repaints the header text. Zero rows, zero
+   * geometry movement — OVERLAY_LINES is untouched.
+   */
+  notifyIndexProgress(processed: number, total: number): void {
+    this.indexProgress = processed >= total ? null : { processed, total };
+    this.rebuildList();
+  }
+
+  // -- Selection actions --------------------------------------------------
+
+  private selectCurrent(): void {
+    const selected = this.filteredRecords[this.selectedIndex];
+    if (selected) this.onSelect(selected);
+  }
+
+  /**
+   * Toggle project <-> global (design v2): re-drain the other scope,
+   * rebuild the merged records, reset the window. Tab's only role.
+   */
+  private toggleScope(): void {
+    this.scope = this.scope === "project" ? "global" : "project";
+    const entries = drainForScope(this.scope);
+    this.records = recordsFromEntries(entries);
+    this.loadedCount = initialLoadedCount(this.records.length, INITIAL_BATCH);
+    this.applyFilter(this.searchInput.getValue());
+  }
+
+  /** Delete the currently selected prompt from disk and refresh the list. */
+  private deleteCurrent(): void {
+    const selected = this.filteredRecords[this.selectedIndex];
+    if (!selected) return;
+
+    // C4 delete flows (design §F): the record's provenance decides the
+    // actions via the pure planner; module constants are used directly.
+    const actions = deletionActionsFor(selected.source ?? "editor");
+
+    if (actions.deleteFromEditorStore) {
+      // Store path: physically remove EVERY copy from the JSONL store
+      // (memory + file in one atomic rewrite).
+      const { removed } =
+        this.scope === "global"
+          ? deleteFromGlobal(PI_HISTORY_ROOT, selected.text)
+          : deleteFromProject(PI_HISTORY_ROOT, CURRENT_CWD, selected.text);
+      if (removed === 0) return;
+    }
+
+    // Tombstone ALWAYS: the session transcripts are immutable and would
+    // re-supply the deleted prompt on the next merge (hide-file suppresses
+    // the twin). Only the session path aborts on a hide error — the store
+    // row is already gone on the editor path, so the splice proceeds.
+    const hide = hidePrompt(PI_HISTORY_NAV_STATE_DIR, selected.text);
+    if (hide.status === "error") {
+      this.onNotify?.(hide.message, "error");
+      if (!actions.deleteFromEditorStore) {
+        return;
+      }
+    }
+    // Remove from the master records array so a subsequent filter doesn't
+    // bring it back.
+    const idx = this.records.indexOf(selected);
+    if (idx !== -1) {
+      this.records.splice(idx, 1);
+      // C4 delete backfill (design §B3): shrink the window with the splice,
+      // then pull the next unloaded row while any remain — genuine shrink
+      // only at exhaustion.
+      this.loadedCount = loadedCountAfterDelete(
+        this.loadedCount,
+        this.records.length,
+      );
+    }
+
+    // Re-apply current filter (rebuilds filteredRecords, list, preview).
+    this.applyFilter(this.searchInput.getValue());
+  }
+
+  // -- Navigation ---------------------------------------------------------
+
+  private moveUp(): void {
+    this.selectedIndex = moveSelectedIndex(
+      this.selectedIndex,
+      this.filteredRecords.length,
+      -1,
+    );
+    if (
+      shouldGrowWindow(
+        this.selectedIndex,
+        this.loadedCount,
+        this.records.length,
+        PRELOAD_BUFFER,
+      )
+    ) {
+      this.loadedCount = nextLoadedCount(
+        this.loadedCount,
+        this.records.length,
+        BATCH_SIZE,
+      );
+      this.applyFilter(this.searchInput.getValue());
+    }
+    this.previewScrollOffset = 0;
+    this.rebuildList();
+    this.rebuildPreview();
+  }
+
+  private moveDown(): void {
+    // Grow-before-move (design §D1): the C2 trigger fires while the cursor
+    // sits in the final PRELOAD_BUFFER rows of the loaded window, so the
+    // modulo below moves into freshly loaded rows — a wrap to index 0 is
+    // reachable only on the exhausted set.
+    if (
+      shouldGrowWindow(
+        this.selectedIndex,
+        this.loadedCount,
+        this.records.length,
+        PRELOAD_BUFFER,
+      )
+    ) {
+      this.loadedCount = nextLoadedCount(
+        this.loadedCount,
+        this.records.length,
+        BATCH_SIZE,
+      );
+      this.applyFilter(this.searchInput.getValue());
+    }
+    this.selectedIndex = moveSelectedIndex(
+      this.selectedIndex,
+      this.filteredRecords.length,
+      1,
+    );
+    this.previewScrollOffset = 0;
+    this.rebuildList();
+    this.rebuildPreview();
+  }
+
+  /** Page the LIST up by MAX_VISIBLE with clamping (no wrap). */
+  private pageListUp(): void {
+    this.selectedIndex = pageSelectedIndex(
+      this.selectedIndex,
+      this.filteredRecords.length,
+      -MAX_VISIBLE,
+    );
+    this.previewScrollOffset = 0;
+    this.rebuildList();
+    this.rebuildPreview();
+  }
+
+  /** Page the LIST down by MAX_VISIBLE with clamping (no wrap). */
+  private pageListDown(): void {
+    // PgDn catch-up (design §D7): grow in whole batches until the paged-to
+    // row is loaded BEFORE the selection lands on it.
+    const grown = loadedCountForTarget(
+      this.loadedCount,
+      this.records.length,
+      this.selectedIndex + MAX_VISIBLE,
+      BATCH_SIZE,
+    );
+    if (grown !== this.loadedCount) {
+      this.loadedCount = grown;
+      this.applyFilter(this.searchInput.getValue());
+    }
+    this.selectedIndex = pageSelectedIndex(
+      this.selectedIndex,
+      this.filteredRecords.length,
+      MAX_VISIBLE,
+    );
+    this.previewScrollOffset = 0;
+    this.rebuildList();
+    this.rebuildPreview();
+  }
+
+  private previewPageUp(): void {
+    this.previewScrollOffset = Math.max(
+      0,
+      this.previewScrollOffset - PREVIEW_ROWS,
+    );
+    this.rebuildPreview();
+  }
+
+  private previewPageDown(): void {
+    this.previewScrollOffset = clampPreviewOffset(
+      this.previewScrollOffset + PREVIEW_ROWS,
+      this.wrappedPreviewLines.length,
+      PREVIEW_ROWS,
+    );
+    this.rebuildPreview();
+  }
+
+  private jumpToFirst(): void {
+    if (this.filteredRecords.length === 0) return;
+    this.selectedIndex = 0;
+    this.previewScrollOffset = 0;
+    this.rebuildList();
+    this.rebuildPreview();
+  }
+
+  private jumpToLast(): void {
+    // End full-jump (design §D7): one-shot load of everything BEFORE the
+    // empty guard, so End also surfaces matches beyond the window.
+    if (this.loadedCount < this.records.length) {
+      this.loadedCount = this.records.length;
+      this.applyFilter(this.searchInput.getValue());
+    }
+    if (this.filteredRecords.length === 0) return;
+    this.selectedIndex = this.filteredRecords.length - 1;
+    this.previewScrollOffset = 0;
+    this.rebuildList();
+    this.rebuildPreview();
+  }
+
+  // -- Input handling -----------------------------------------------------
+
+  private forwardToSearch(data: string): void {
+    this.searchInput.handleInput(data);
+    this.selectedIndex = 0;
+    this.applyFilter(this.searchInput.getValue());
+  }
+
+  handleInput(data: string): void {
+    const kb = getKeybindings();
+    let handled = false;
+    for (const { match, handler } of this.dispatch) {
+      if (match(data, kb)) {
+        handler();
+        handled = true;
+        break;
+      }
+    }
+    if (!handled) this.forwardToSearch(data);
+    this.tui.requestRender();
+  }
+
+  // -- Mouse (wheel-only) -------------------------------------------------
+
+  /**
+   * Wheel-only mouse handling over the fixed 30-row geometry (design
+   * §D6). Non-wheel events stay host-owned (undefined = Container child
+   * dispatch); EVERY wheel path — including the no-op regions — reaches
+   * the single consumed return, closing the pre-existing SGR-fallthrough
+   * hazard where raw wheel bytes were typed into the search box.
+   */
+  override handleMouse(
+    event: TuiMouseEvent,
+  ): ReturnType<Container["handleMouse"]> {
+    if (event.type !== "wheel") return undefined;
+    const delta = event.wheelDelta ?? 0;
+    if (event.y >= LIST_WHEEL_Y_FIRST && event.y <= LIST_WHEEL_Y_LAST) {
+      const steps = Math.min(Math.abs(delta), this.filteredRecords.length);
+      for (let i = 0; i < steps; i++) {
+        if (delta > 0) this.moveDown();
+        else this.moveUp();
+      }
+    } else if (
+      event.y >= PREVIEW_WHEEL_Y_FIRST &&
+      event.y <= PREVIEW_WHEEL_Y_LAST
+    ) {
+      if (delta !== 0) {
+        this.previewScrollOffset = clampPreviewOffset(
+          this.previewScrollOffset + (delta > 0 ? 1 : -1),
+          this.wrappedPreviewLines.length,
+          PREVIEW_ROWS,
+        );
+        this.rebuildPreview();
+      }
+    }
+    return {
+      handled: true,
+      target: {
+        component: this,
+        originX: event.screenX - event.x,
+        originY: event.screenY - event.y,
+        width: event.width,
+        height: event.height,
+      },
+    };
+  }
+
+  // -- Render override for dynamic entry width ---------------------------
+
+  /** Fixed overlay height so the TUI never repositions the panel. */
+  private static readonly OVERLAY_LINES = 30;
+
+  override render(width: number): string[] {
+    if (width !== this.lastWidth) {
+      // Pre-clamp against the previous wrap so a width change can never
+      // drive the rebuilds with a stale selection/offset (AC-P1-4.1/4.2).
+      this.selectedIndex = clampSelectedIndex(
+        this.selectedIndex,
+        this.filteredRecords.length,
+      );
+      this.previewScrollOffset = clampPreviewOffset(
+        this.previewScrollOffset,
+        this.wrappedPreviewLines.length,
+        PREVIEW_ROWS,
+      );
+    }
+    this.lastWidth = width;
+    this.rebuildListWithWidth(width);
+    this.rebuildPreviewWithWidth(width);
+    const raw = super.render(width);
+    // Pad or trim to exactly OVERLAY_LINES so the overlay never shifts.
+    const blank = " ".repeat(Math.max(1, width));
+    while (raw.length < PromptHistorySelector.OVERLAY_LINES) raw.push(blank);
+    return raw.slice(0, PromptHistorySelector.OVERLAY_LINES);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Extension entry point
+// ---------------------------------------------------------------------------
+
+type SelectorDone = (result: PromptRecord | null) => void;
+
+type SelectorFactory = (
+  tui: unknown,
+  theme: unknown,
+  keybindings: unknown,
+  done: SelectorDone,
+) => PromptHistorySelector;
+
+function castSelectorArgs(tui: unknown, theme: unknown): [TUI, Theme] {
+  return [tui as TUI, theme as Theme];
+}
+
+/** Stored close callback for the currently-open overlay. Null when closed. */
+let activeOverlayClose: (() => void) | null = null;
+
+/**
+ * Progress sink for the background index build (spec C6, design §D7): set by
+ * the selector factory beside activeOverlayClose, nulled in finish. Status
+ * text only — merged records and counters are never swapped mid-open.
+ */
+let activeIndexProgressNotify:
+  | ((processed: number, total: number) => void)
+  | null = null;
+
+function createPromptHistorySelectorFactory(
+  records: PromptRecord[],
+  onNotify?: SelectorNotify,
+): SelectorFactory {
+  return (tui, theme, _keybindings, done) => {
+    selectorTui = tui as { requestRender(): void };
+    const finish = (result: PromptRecord | null) => {
+      activeOverlayClose = null;
+      activeIndexProgressNotify = null;
+      done(result);
+    };
+    // Expose close so the tool_call handler can dismiss the overlay.
+    activeOverlayClose = () => finish(null);
+    const [typedTui, typedTheme] = castSelectorArgs(tui, theme);
+    const selector = new PromptHistorySelector(
+      typedTui,
+      typedTheme,
+      records,
+      (record) => finish(record),
+      () => finish(null),
+      onNotify,
+    );
+    // Wire the transient indexing suffix (design §D7): the live
+    // selector's header is the only consumer; finish() nulls the sink.
+    activeIndexProgressNotify = (processed, total) =>
+      selector.notifyIndexProgress(processed, total);
+    return selector;
+  };
+}
+
+async function runPromptHistorySelection(
+  ctx: ShortcutContext,
+  records: PromptRecord[],
+): Promise<PromptRecord | null> {
+  const historyGlobals: PiHistoryGlobals = globalThis as Record<
+    string,
+    unknown
+  >;
+  return withExpandedHistoryGlobals(historyGlobals, async () =>
+    ctx.ui.custom<PromptRecord | null>(
+      createPromptHistorySelectorFactory(records, (message, level) =>
+        ctx.ui.notify(message, level),
+      ),
+      {
+        overlay: true,
+        overlayOptions: { anchor: "bottom-center", width: "100%", offsetY: 5 },
+      },
+    ),
+  );
+}
+
+/** Shared entry point for the ctrl+shift+r shortcut and the /history command. */
+// ---------------------------------------------------------------------------
+// Multi-concurrency store (v2): per-session writes, scope drains
+// ---------------------------------------------------------------------------
+
+type HistoryScope = "project" | "global";
+
+/** TUI handle captured when the selector overlay mounts. */
+let selectorTui: { requestRender(): void } | null = null;
+
+let writerState: SessionWriterState | null = null;
+
+/**
+ * One-time init per extension load: migrate legacy stores, register the
+ * project, bootstrap the seed, then open this instance's exclusive file.
+ */
+function getWriter(): SessionWriterState {
+  if (!writerState) {
+    try {
+      migrateLegacyStores(PI_HISTORY_ROOT, AGENT_DIR);
+    } catch {
+      // migration is best-effort; the gate keeps it one-shot
+    }
+    try {
+      ensureRegistryEntry(PI_HISTORY_ROOT, CURRENT_CWD);
+    } catch {
+      // registry is advisory
+    }
+    try {
+      bootstrapProjectSeed(
+          PI_HISTORY_ROOT,
+          CURRENT_CWD,
+          SESSIONS_ROOT,
+          500,
+          PI_HISTORY_NAV_STATE_DIR,
+        );
+    } catch {
+      // bootstrap is a rebuildable cache
+    }
+    writerState = openSessionWriter(PI_HISTORY_ROOT, CURRENT_CWD, INSTANCE_ID);
+  }
+  return writerState;
+}
+
+/**
+ * Scope drain for the selector: project scope merges the project's store
+ * files with the live session-index view; global scope is the store-only
+ * cross-project view (all project dirs + the legacy global seed).
+ */
+function drainForScope(scope: HistoryScope): string[] {
+  getWriter(); // ensure init ran
+  return scope === "project"
+    ? drainProject(PI_HISTORY_ROOT, CURRENT_CWD, 1000, PI_HISTORY_NAV_STATE_DIR)
+    : drainGlobal(PI_HISTORY_ROOT, 1000, PI_HISTORY_NAV_STATE_DIR);
+}
+
+async function openHistorySelector(
+  ctx: Pick<ShortcutContext, "ui">,
+): Promise<void> {
+  // Store-only drain (user-directed): both scopes read the store files
+  // symmetrically — no live transcript merge (the one-time seed bootstrap
+  // covers pre-store history).
+  const entries = drainForScope("project");
+  if (entries.length === 0) {
+    ctx.ui.notify("No prompt history available.", "warning");
+    return;
+  }
+
+  const records = recordsFromEntries(entries);
+  const selected = await runPromptHistorySelection(ctx, records);
+  if (selected) {
+    // pasteToEditor routes through the editor's input pipeline
+    // (bracketed paste), so the text renders immediately. Plain
+    // setText left the editor stale until the next keypress after
+    // overlay close.
+    ctx.ui.pasteToEditor(selected.text);
+    // The overlay teardown can race the paste render: force one more
+    // frame on the next tick so the editor box shows the text at once.
+    setTimeout(() => selectorTui?.requestRender(), 0);
+  }
+}
+
+/** Build selector records from merged/drain entries (shared by both scopes). */
+function recordsFromEntries(
+  entries: Array<string | PromptEntry>,
+): PromptRecord[] {
+  return buildPromptRecords(dedupePromptEntries(entries));
+}
+
+export default function promptHistoryExtension(pi: ExtensionAPI) {
+  // One writer per extension load; see getWriter() for the init order.
+
+  // Persist every delivered user prompt (write-through, append-only JSONL).
+  // The local ExtensionAPI stub types handler args as unknown; narrow here.
+    pi.on("before_agent_start", (...args: unknown[]) => {
+    try {
+      const event = args[0] as { prompt?: string } | undefined;
+      appendSessionCapture(getWriter(), event?.prompt ?? "", Date.now());
+    } catch {
+      // A capture failure must never break the agent loop or unregister
+      // the handler - swallow and keep the next prompt capturable.
+    }
+  });
+
+  // Backup pass: enforce the 1000-line limit on graceful shutdown.
+    pi.on("session_shutdown", () => {
+    try {
+      gcProjectDir(PI_HISTORY_ROOT, CURRENT_CWD);
+    } catch {
+      // GC is best-effort
+    }
+  });
+
+  // When a tool asks for user input while the history overlay is open,
+  // dismiss the overlay so the tool can take over the UI.
+  pi.on("tool_call", () => {
+    activeOverlayClose?.();
+  });
+
+  pi.registerShortcut(SHORTCUT, {
+    description: "Search prompt history",
+    handler: async (ctx) => openHistorySelector(ctx),
+  });
+
+  pi.registerCommand("history", {
+    description: "Search prompt history",
+    handler: async (_args, ctx) => openHistorySelector(ctx),
+  });
+}

--- a/extensions/history/load-shared-history.ts
+++ b/extensions/history/load-shared-history.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs";
+
+interface SharedHistoryEntry {
+	text: string;
+}
+
+function isSharedHistoryEntry(value: unknown): value is SharedHistoryEntry {
+	if (!value || typeof value !== "object") return false;
+	return typeof (value as { text?: unknown }).text === "string";
+}
+
+function toSharedHistoryValue(value: unknown): string | null {
+	if (typeof value === "string") return value.length > 0 ? value : null;
+	if (isSharedHistoryEntry(value))
+		return value.text.length > 0 ? value.text : null;
+	return null;
+}
+
+function isNonEmptyString(value: string | null): value is string {
+	return typeof value === "string" && value.length > 0;
+}
+
+export function loadSharedHistory(historyFile: string): string[] {
+	if (!fs.existsSync(historyFile)) return [];
+
+	try {
+		const raw = fs.readFileSync(historyFile, "utf8");
+		const parsed: unknown = JSON.parse(raw);
+
+		if (!Array.isArray(parsed)) return [];
+
+		return parsed.map(toSharedHistoryValue).filter(isNonEmptyString);
+	} catch {
+		return [];
+	}
+}

--- a/extensions/history/merge-history.ts
+++ b/extensions/history/merge-history.ts
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 ExoPro. Inspired by @jasonish/pi-prompt-history
+// SPDX-License-Identifier: MIT
+
+import { loadHiddenPrompts } from "./hide-prompts.ts";
+import {
+  collectSessionEntries,
+  loadSessionIndex,
+  refreshSessionIndex,
+  startBackgroundIndexBuild,
+} from "./session-index.ts";
+import { promptDedupKey, type PromptEntry } from "./selector-helpers.ts";
+
+/** Options for the combined editor+session loader (spec C3). */
+export interface MergeHistoryOptions {
+  /** Editor-store entries in file order (newest-known-first), pre-dedup. */
+  editorEntries: readonly string[];
+  /** pi-history-nav state dir holding prompt-index.json and hidden.json. */
+  stateDir: string;
+  /** pi sessions root scanned one level deep for session transcripts. */
+  sessionsRoot: string;
+  /** Sync rescan budget; above it the refresh defers to the background build. */
+  syncChangedFileLimit?: number;
+  /** Progress sink for the background build (p/t), wired to the header suffix. */
+  onIndexProgress?: (processed: number, total: number) => void;
+}
+
+/**
+ * THE combined loader (spec C3, design §E): editor block first in input
+ * order, then the session-derived block newest-first by ts. The tombstone
+ * pre-filter scopes the SESSION half only — after index load, before merge —
+ * so the editor store governs itself. No cross-block time interleaving is
+ * attempted (accepted R8 seam). Returns the PRE-dedup combined array: the
+ * Change 2 keep-first dedup stays with the caller (openHistorySelector), so
+ * dedupePromptEntries over this output makes the editor copy win at the
+ * seam. Cold start (missing or corrupt index) and a DEFERRED mass-change
+ * refresh (WU2b seam, design §D7) both hand the rescan to the chunked
+ * background build — never awaited here; onIndexProgress rides along. Every
+ * underlying module is fail-open, so this call never throws.
+ */
+export function mergeHistoryEntries(
+  options: MergeHistoryOptions,
+): PromptEntry[] {
+  const editorBlock: PromptEntry[] = options.editorEntries.map((text) => ({
+    text,
+    source: "editor",
+  }));
+
+  const loaded = loadSessionIndex(options.stateDir);
+  if (loaded === null) {
+    // Cold start (§D8): the build runs behind this open — the session half
+    // is empty THIS open; the fruits appear from the next one.
+    startBackgroundIndexBuild({
+      stateDir: options.stateDir,
+      sessionsRoot: options.sessionsRoot,
+      onProgress: options.onIndexProgress,
+    });
+    return editorBlock;
+  }
+
+  const refresh = refreshSessionIndex({
+    sessionsRoot: options.sessionsRoot,
+    index: loaded,
+    stateDir: options.stateDir,
+    syncChangedFileLimit: options.syncChangedFileLimit,
+  });
+  if (refresh.deferred) {
+    // Mass-change (§D7): the stale index was served this open; the chunked
+    // background build owns the rescan, progress wired through.
+    startBackgroundIndexBuild({
+      stateDir: options.stateDir,
+      sessionsRoot: options.sessionsRoot,
+      onProgress: options.onIndexProgress,
+    });
+  }
+
+  const hidden = loadHiddenPrompts(options.stateDir);
+  const sessionBlock: PromptEntry[] = collectSessionEntries(refresh.index)
+    .filter((entry) => !hidden.has(promptDedupKey(entry.text)))
+    .map((entry) => ({ text: entry.text, source: "session", ts: entry.ts }));
+
+  return [...editorBlock, ...sessionBlock];
+}

--- a/extensions/history/selector-helpers.ts
+++ b/extensions/history/selector-helpers.ts
@@ -1,0 +1,318 @@
+export interface PromptRecord {
+	text: string;
+	searchText: string;
+	/**
+	 * Provenance (spec C3): set on records built from PromptEntry inputs;
+	 * ABSENT on records built from bare strings so the pinned deepEqual
+	 * record shape ({text, searchText}) stays byte-compatible (design §I).
+	 */
+	source?: PromptSource;
+	/** Session records only: the resolved ms-epoch ordering timestamp. */
+	ts?: number;
+}
+
+/** Provenance of a prompt record or merge-loader entry (spec C3). */
+export type PromptSource = "editor" | "session";
+
+/**
+ * Merge-loader currency (pre-dedup, spec C3): one editor-store or
+ * session-derived prompt. Session entries carry the resolved ms-epoch `ts`;
+ * editor entries do not (block ordering at the seam, proposal R8).
+ */
+export interface PromptEntry {
+	text: string;
+	source: PromptSource;
+	ts?: number;
+}
+
+export interface VisibleRange {
+	start: number;
+	end: number;
+}
+
+export interface VisiblePromptRecord {
+	index: number;
+	record: PromptRecord;
+	isSelected: boolean;
+}
+
+export interface PiHistoryGlobals {
+	__piHistoryExpand?: () => void;
+	__piHistoryTrim?: () => void;
+}
+
+export function buildPromptRecords(
+	entries: ReadonlyArray<string | PromptEntry>,
+): PromptRecord[] {
+	return entries.map((entry): PromptRecord => {
+		if (typeof entry === "string") {
+			// Bare string input keeps the EXACT Change 2 runtime shape — the
+			// pinned deepEqual records carry only {text, searchText}.
+			return { text: entry, searchText: entry.toLowerCase() };
+		}
+		const record: PromptRecord = {
+			text: entry.text,
+			searchText: entry.text.toLowerCase(),
+			source: entry.source,
+		};
+		if (entry.ts !== undefined) {
+			record.ts = entry.ts;
+		}
+		return record;
+	});
+}
+
+export function clampSelectedIndex(
+	selectedIndex: number,
+	total: number,
+): number {
+	return Math.max(0, Math.min(selectedIndex, Math.max(0, total - 1)));
+}
+
+export function clampPreviewOffset(
+	offset: number,
+	totalLines: number,
+	viewportRows: number,
+): number {
+	return Math.max(0, Math.min(offset, Math.max(0, totalLines - viewportRows)));
+}
+
+export function computeVisibleRange(
+	selectedIndex: number,
+	total: number,
+	maxVisible: number,
+): VisibleRange {
+	if (total <= 0 || maxVisible <= 0) return { start: 0, end: 0 };
+	if (total <= maxVisible) return { start: 0, end: total };
+
+	const half = Math.floor(maxVisible / 2);
+	const start = Math.max(0, Math.min(selectedIndex - half, total - maxVisible));
+
+	return {
+		start,
+		end: Math.min(start + maxVisible, total),
+	};
+}
+
+export function moveSelectedIndex(
+	selectedIndex: number,
+	total: number,
+	delta: number,
+): number {
+	if (total === 0) return 0;
+	return (selectedIndex + delta + total) % total;
+}
+
+export function pageSelectedIndex(
+	selectedIndex: number,
+	total: number,
+	pageSize: number,
+): number {
+	if (total === 0) return 0;
+	return clampSelectedIndex(selectedIndex + pageSize, total);
+}
+
+/**
+ * Normalization key for read-time dedup (spec C3): byte-matches the
+ * APPLIED patch key in nav/patches/editor.cjs (:480-:586) — whitespace
+ * runs collapse, then trim, then a 120-char prefix slice, then lowercase.
+ * The literal is the single-backslash applied-patch form; the raw patch
+ * file stores \\s+ only because its code sits inside a template literal.
+ * Shared by contract (spec C4): hide-prompts tombstone keys and the
+ * merge-history session-half tombstone filter MUST byte-match this key.
+ */
+export function promptDedupKey(entry: string): string {
+	return entry.replace(/\s+/g, " ").trim().slice(0, 120).toLowerCase();
+}
+
+/**
+ * Read-time dedup pass (spec C3): keep-first over input order (file order
+ * is newest-first, mirroring the patch's keep-first dedup-on-save), and
+ * empty-key entries (empty or whitespace-only) are skipped — excluded from
+ * the output and never usable as collision keys. Removes ONLY duplicate-
+ * normalized entries; no snapshot cap (filterPrompts still caps output).
+ * Generic over string | PromptEntry (WU3): over the COMBINED merged input
+ * the keep-first rule makes the editor copy win at the seam — objects pass
+ * through with provenance intact; no new dedup logic exists anywhere.
+ */
+export function dedupePromptEntries<T extends string | PromptEntry>(
+	entries: readonly T[],
+): T[] {
+	const seen = new Set<string>();
+	const deduped: T[] = [];
+	for (const entry of entries) {
+		const key =
+			typeof entry === "string"
+				? promptDedupKey(entry)
+				: promptDedupKey(entry.text);
+		if (key !== "" && !seen.has(key)) {
+			seen.add(key);
+			deduped.push(entry);
+		}
+	}
+	return deduped;
+}
+
+/**
+ * First-paint window size (spec C1, AC-L1-1): min(initialBatch, total),
+ * floored at 0 — small stores open fully loaded (exhausted at open),
+ * identical to today's behavior for R <= INITIAL_BATCH.
+ */
+export function initialLoadedCount(
+	total: number,
+	initialBatch: number,
+): number {
+	return Math.max(0, Math.min(initialBatch, total));
+}
+
+/**
+ * Prefetch trigger (spec C2's normative expression, AC-L2-1): growth fires
+ * iff rows remain unloaded AND the 0-based cursor sits within the final
+ * preloadBuffer rows of the loaded window. Reads UNFILTERED counts only —
+ * filteredRecords.length appears in no trigger arithmetic (AC-L2-2).
+ */
+export function shouldGrowWindow(
+	selectedIndex: number,
+	loadedCount: number,
+	totalCount: number,
+	preloadBuffer: number,
+): boolean {
+	return (
+		loadedCount < totalCount && selectedIndex + preloadBuffer >= loadedCount
+	);
+}
+
+/**
+ * One growth step (spec C2, AC-L2-1): min(L + max(1, batchSize), R). The
+ * max(1, ·) guard also keeps loadedCountForTarget's loop terminating on a
+ * degenerate batch size.
+ */
+export function nextLoadedCount(
+	loadedCount: number,
+	totalCount: number,
+	batchSize: number,
+): number {
+	const step = Math.max(1, batchSize);
+	return Math.min(loadedCount + step, totalCount);
+}
+
+/**
+ * PgDn catch-up (spec C1, AC-L1-5): the smallest whole-batch count that
+ * strictly covers targetIndex (a 0-based master row), clamped at totalCount.
+ * No-op when the target is already covered or the window is exhausted.
+ * Terminates by construction: each step adds ≥ 1, bounded by totalCount.
+ */
+export function loadedCountForTarget(
+	loadedCount: number,
+	totalCount: number,
+	targetIndex: number,
+	batchSize: number,
+): number {
+	let next = loadedCount;
+	while (next <= targetIndex && next < totalCount) {
+		next = nextLoadedCount(next, totalCount, batchSize);
+	}
+	return next;
+}
+
+/**
+ * Delete backfill (spec C4's two steps verbatim, AC-L4-1..3): decrement the
+ * window against the splice-shrunk snapshot; while unloaded rows remain,
+ * backfill one row (clamped) so the next unloaded record slides into the
+ * deleted slot and the visible list length stays stable; at exhaustion the
+ * decrement is the genuine shrink. Written stepwise — NOT the algebraic
+ * min(L, T') shortcut — so the unit tests pin the contract, not an
+ * equivalence. Callers guarantee the deleted row sits inside the loaded
+ * prefix (idx < loadedCount by construction).
+ */
+export function loadedCountAfterDelete(
+	loadedCount: number,
+	totalCountAfterSplice: number,
+): number {
+	const decrement = loadedCount - 1;
+	if (decrement < totalCountAfterSplice) {
+		return Math.min(decrement + 1, totalCountAfterSplice);
+	}
+	return decrement;
+}
+
+/**
+ * Pure delete-flow planner (spec C4, design §F): maps a record's provenance
+ * to the two delete actions. "editor" deletes from the editor store on disk
+ * AND writes the tombstone (twin suppression — the session copy of the same
+ * text would otherwise resurface next open); "session" writes the tombstone
+ * only (session transcripts are NEVER written). Takes source as a plain
+ * parameter (no member reads — the T23 provenance pin keeps overlay
+ * consumers source-agnostic outside deleteCurrent); the only consumer is
+ * deleteCurrent in history/index.ts.
+ */
+export function deletionActionsFor(
+	source: PromptSource,
+): { deleteFromEditorStore: boolean; writeTombstone: boolean } {
+	if (source === "editor") {
+		return { deleteFromEditorStore: true, writeTombstone: true };
+	}
+	return { deleteFromEditorStore: false, writeTombstone: true };
+}
+
+export function getVisiblePromptRecords(
+	records: PromptRecord[],
+	selectedIndex: number,
+	maxVisible: number,
+): VisiblePromptRecord[] {
+	const { start, end } = computeVisibleRange(
+		selectedIndex,
+		records.length,
+		maxVisible,
+	);
+	return records.slice(start, end).map((record, offset) => ({
+		index: start + offset,
+		record,
+		isSelected: start + offset === selectedIndex,
+	}));
+}
+
+export async function withExpandedHistoryGlobals<T>(
+	globals: PiHistoryGlobals,
+	run: () => Promise<T>,
+): Promise<T> {
+	globals.__piHistoryExpand?.();
+	try {
+		return await run();
+	} finally {
+		globals.__piHistoryTrim?.();
+	}
+}
+
+/**
+ * Full-snapshot visibility for non-empty queries (AC-L2-3r, user-directed
+ * 2026-09-08): searching must see the whole deduped snapshot, not just the
+ * loaded prefix. One-shot and idempotent — returns the total, never an
+ * incremental batch — so per-keypress growth stays impossible. Empty or
+ * whitespace-only queries leave the lazy window untouched.
+ */
+export function loadedCountForQuery(
+	loadedCount: number,
+	totalCount: number,
+	query: string,
+): number {
+	return query.trim().length > 0 ? totalCount : loadedCount;
+}
+
+const MAX_RESULTS = 10000;
+
+export function filterPrompts(
+  records: PromptRecord[],
+  query: string,
+): PromptRecord[] {
+	const trimmed = query.trim();
+	if (!trimmed) return records.slice(0, MAX_RESULTS);
+
+	const tokens = trimmed.toLowerCase().split(/\s+/).filter(Boolean);
+	const filtered = records.filter((record) => {
+		return tokens.every((token) => record.searchText.includes(token));
+	});
+
+	return filtered.slice(0, MAX_RESULTS);
+}
+

--- a/extensions/history/session-index.ts
+++ b/extensions/history/session-index.ts
@@ -1,0 +1,316 @@
+// SPDX-FileCopyrightText: 2026 ExoPro. Inspired by @jasonish/pi-prompt-history
+// SPDX-License-Identifier: MIT
+
+import fs from "node:fs";
+import path from "node:path";
+import { writeJsonAtomic } from "./atomic-write.ts";
+import { extractPromptsFromFile, listSessionFiles } from "./session-scan.ts";
+
+/**
+ * Schema version of prompt-index.json. An index carrying any other version
+ * is discarded at load and fully rebuilt (fail-open, AC-S2-4).
+ */
+export const SESSION_INDEX_VERSION = 1;
+
+/**
+ * Index file name inside the injected state dir (design §D5). The module is
+ * storage-dir agnostic: production wiring passes the pi-history-nav state
+ * dir, tests pass injected temp dirs.
+ */
+const INDEX_FILE_NAME = "prompt-index.json";
+
+/**
+ * One user prompt in the index: the extracted text plus the resolved
+ * ms-epoch ordering timestamp (fallback chain applied at scan time).
+ */
+export interface SessionPromptRecord {
+  text: string;
+  ts: number;
+}
+
+/**
+ * Per-file freshness record. The file's ABSOLUTE PATH is the object KEY of
+ * `SessionIndexState.files` (design §D5 ratification: single source of
+ * identity, O(1) freshness lookup, deterministic `Object.keys().sort()`
+ * flatten order). `(mtimeMs, size)` is the freshness pair — append-only
+ * transcripts make it sound.
+ */
+export interface SessionFileRecord {
+  mtimeMs: number;
+  size: number;
+  prompts: SessionPromptRecord[];
+}
+
+/**
+ * The whole persisted index state. `version` must equal
+ * SESSION_INDEX_VERSION or the state is discarded at load.
+ */
+export interface SessionIndexState {
+  version: number;
+  files: Record<string, SessionFileRecord>;
+}
+
+/**
+ * Load the session index from `stateDir/prompt-index.json`. Fail-open
+ * (AC-S2-4): a missing, unreadable, unparseable, wrong-version, or
+ * wrong-shaped index is DISCARDED — null, identical to cold start — and the
+ * call never throws. The selector never crashes on index state.
+ */
+export function loadSessionIndex(stateDir: string): SessionIndexState | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(path.join(stateDir, INDEX_FILE_NAME), "utf8");
+  } catch {
+    return null; // missing or unreadable → cold start
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null; // unparseable garbage → discard
+  }
+  if (parsed == null || typeof parsed !== "object") return null;
+  const state = parsed as SessionIndexState;
+  if (state.version !== SESSION_INDEX_VERSION) return null;
+  if (
+    state.files == null ||
+    typeof state.files !== "object" ||
+    Array.isArray(state.files)
+  ) {
+    return null; // wrong shape → discard
+  }
+  return state;
+}
+
+/**
+ * Persist the session index into `stateDir/prompt-index.json` through the
+ * shared atomic tmp+rename writer. Returns true on success; a write failure
+ * returns false and never throws (cache semantics — silent, design §D3).
+ */
+export function persistSessionIndex(
+  stateDir: string,
+  index: SessionIndexState,
+): boolean {
+  return writeJsonAtomic(path.join(stateDir, INDEX_FILE_NAME), index);
+}
+
+// ---------------------------------------------------------------------------
+// WU2b — freshness: stat-pass refresh, stable collect, chunked background build
+// ---------------------------------------------------------------------------
+
+/** Default synchronous rescan budget per open (design §D7). */
+export const DEFAULT_SYNC_CHANGED_FILE_LIMIT = 64;
+
+/** Options for one incremental refresh pass over the sessions root. */
+export interface RefreshSessionIndexOptions {
+  sessionsRoot: string;
+  index: SessionIndexState;
+  stateDir: string;
+  /**
+   * Max changed+new+dropped files rescanned synchronously per open. Above it
+   * the STALE index is served and the rescan is handed to the chunked
+   * background build — bounded open latency (design §D7, §Risk 8).
+   */
+  syncChangedFileLimit?: number;
+}
+
+/** Result of one incremental refresh pass (the C2 open path). */
+export interface RefreshResult {
+  /** The index to serve THIS open: refreshed, or the stale input when deferred. */
+  index: SessionIndexState;
+  /** Files actually rescanned synchronously (empty when nothing changed or deferred). */
+  changedPaths: string[];
+  /** True when exactly one atomic persist wrote the refreshed index. */
+  persisted: boolean;
+  /** True when changes exceeded the sync limit and were deferred to the background build. */
+  deferred: boolean;
+}
+
+/**
+ * One incremental refresh pass (AC-S2-1..3): one-level candidate discovery,
+ * then an O(files) statSync pass — never O(bytes). Unchanged (mtimeMs, size)
+ * pairs serve their cached records; changed or new files are rescanned once
+ * via extractPromptsFromFile; records whose file is gone from disk drop. Any
+ * applied change persists exactly once, atomically. A mass change above
+ * `syncChangedFileLimit` defers: the stale index is returned untouched
+ * (deferred: true) and the rescan is handed to the chunked background build.
+ * Never throws: a file that vanishes between listing and stat is treated as
+ * deleted, and persistence failures stay silent cache semantics (design §D3).
+ */
+export function refreshSessionIndex({
+  sessionsRoot,
+  index,
+  stateDir,
+  syncChangedFileLimit = DEFAULT_SYNC_CHANGED_FILE_LIMIT,
+}: RefreshSessionIndexOptions): RefreshResult {
+  const files = listSessionFiles(sessionsRoot);
+  const listed = new Set(files);
+  const nextFiles: Record<string, SessionFileRecord> = {};
+  const carried = new Set<string>();
+  const changedPaths: string[] = [];
+  let dropped = 0;
+
+  // Deletions first: records whose file no longer exists on disk drop.
+  for (const filePath of Object.keys(index.files)) {
+    if (!listed.has(filePath)) {
+      dropped++;
+      continue;
+    }
+    nextFiles[filePath] = index.files[filePath];
+    carried.add(filePath);
+  }
+
+  // Stat pass over the candidates: rescan ONLY changed or new files.
+  for (const filePath of files) {
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(filePath);
+    } catch {
+      // Vanished between listing and stat → treat as deleted.
+      if (carried.delete(filePath)) dropped++;
+      continue;
+    }
+    const cached: SessionFileRecord | undefined = index.files[filePath];
+    if (
+      cached !== undefined &&
+      cached.mtimeMs === stat.mtimeMs &&
+      cached.size === stat.size
+    ) {
+      continue; // unchanged → the cached record was already carried over
+    }
+    const scan = extractPromptsFromFile(filePath);
+    nextFiles[filePath] = {
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+      prompts: scan.prompts,
+    };
+    changedPaths.push(filePath);
+  }
+
+  const changeCount = changedPaths.length + dropped;
+  if (changeCount > syncChangedFileLimit) {
+    // Mass-touch: serve the STALE index this open; the background build owns
+    // the rescan — bounded open latency, freshness from the next open (§D7).
+    return { index, changedPaths: [], persisted: false, deferred: true };
+  }
+  if (changeCount > 0) {
+    const nextIndex: SessionIndexState = {
+      version: SESSION_INDEX_VERSION,
+      files: nextFiles,
+    };
+    const persisted = persistSessionIndex(stateDir, nextIndex);
+    return { index: nextIndex, changedPaths, persisted, deferred: false };
+  }
+  return { index, changedPaths: [], persisted: false, deferred: false };
+}
+
+/**
+ * Flatten the index into ordering-ready prompt entries: Object.keys() sorted
+ * (deterministic scan order), then a STABLE sort ts descending — equal ts
+ * keep the sorted-path order, and a non-finite ts (ordering-only residue)
+ * sinks to the end deterministically. Never throws on a wrong-shaped record:
+ * values from a fail-open load are treated as unknown at this boundary.
+ */
+export function collectSessionEntries(
+  index: SessionIndexState,
+): SessionPromptRecord[] {
+  const entries: SessionPromptRecord[] = [];
+  const rawFiles: unknown = index.files;
+  for (const filePath of Object.keys(index.files).sort()) {
+    const record = (rawFiles as Record<string, unknown>)[filePath];
+    if (record == null || typeof record !== "object") continue;
+    const rawPrompts = (record as { prompts?: unknown }).prompts;
+    if (!Array.isArray(rawPrompts)) continue;
+    for (const prompt of rawPrompts) {
+      if (prompt == null || typeof prompt !== "object") continue;
+      const fields = prompt as { text?: unknown; ts?: unknown };
+      entries.push({
+        text: typeof fields.text === "string" ? fields.text : "",
+        ts: typeof fields.ts === "number" ? fields.ts : NaN,
+      });
+    }
+  }
+  return entries.sort((a, b) => {
+    const ta = Number.isFinite(a.ts) ? a.ts : -Infinity;
+    const tb = Number.isFinite(b.ts) ? b.ts : -Infinity;
+    return tb - ta;
+  });
+}
+
+/** Files processed per background-build tick (design §D7; measurement-locked). */
+export const INDEX_BUILD_CHUNK = 32;
+
+/** Options for the chunked background index build. */
+export interface BackgroundIndexBuildOptions {
+  stateDir: string;
+  sessionsRoot: string;
+  onProgress?: (processed: number, total: number) => void;
+}
+
+/** Module-level in-flight guard: concurrent builds dedupe onto one promise. */
+let inFlightBuild: Promise<SessionIndexState | null> | null = null;
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+async function runBackgroundBuild(
+  options: BackgroundIndexBuildOptions,
+): Promise<SessionIndexState | null> {
+  try {
+    const files = listSessionFiles(options.sessionsRoot);
+    const total = files.length;
+    const index: SessionIndexState = {
+      version: SESSION_INDEX_VERSION,
+      files: {},
+    };
+    let skippedLines = 0;
+    let processed = 0;
+    for (let start = 0; start < files.length; start += INDEX_BUILD_CHUNK) {
+      const chunk = files.slice(start, start + INDEX_BUILD_CHUNK);
+      for (const filePath of chunk) {
+        // A file that vanishes mid-build throws here — the whole-build catch
+        // below fails open to null (self-healing on the next open).
+        const stat = fs.statSync(filePath);
+        const scan = extractPromptsFromFile(filePath);
+        skippedLines += scan.skippedLines;
+        index.files[filePath] = {
+          mtimeMs: stat.mtimeMs,
+          size: stat.size,
+          prompts: scan.prompts,
+        };
+        processed++;
+      }
+      options.onProgress?.(processed, total);
+      if (start + INDEX_BUILD_CHUNK < files.length) {
+        await yieldToEventLoop(); // yield between ticks, never after the last
+      }
+    }
+    persistSessionIndex(options.stateDir, index); // one atomic persist at completion
+    options.onProgress?.(total, total); // guaranteed terminal total-total call
+    return index;
+  } catch {
+    return null; // fail-open: a failed build self-heals on the next open
+  }
+}
+
+/**
+ * Kick the chunked background index build (design §D7): INDEX_BUILD_CHUNK
+ * files per tick with a setTimeout(0) yield between ticks, one atomic persist
+ * at completion. A second call while a
+ * build is in flight attaches to the SAME promise (no duplicate scan). The
+ * open path never awaits this — tests MAY await it over fixture corpora, and
+ * every tick timer fires before the promise settles, so no timer leaks.
+ */
+export function startBackgroundIndexBuild(
+  options: BackgroundIndexBuildOptions,
+): Promise<SessionIndexState | null> {
+  if (inFlightBuild !== null) return inFlightBuild;
+  const build = runBackgroundBuild(options);
+  inFlightBuild = build.finally(() => {
+    inFlightBuild = null;
+  });
+  return inFlightBuild;
+}

--- a/extensions/history/session-scan.ts
+++ b/extensions/history/session-scan.ts
@@ -1,0 +1,233 @@
+// SPDX-FileCopyrightText: 2026 ExoPro. Inspired by @jasonish/pi-prompt-history
+// SPDX-License-Identifier: MIT
+
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * One user prompt extracted from a pi session transcript file.
+ *
+ * `ts` is the resolved ordering timestamp in milliseconds since the epoch.
+ * It follows the documented fallback chain (message ms-epoch → entry ISO →
+ * header ISO → file mtime) and exists for ordering only — extraction never
+ * fails because of it.
+ */
+export interface ExtractedPrompt {
+  text: string;
+  ts: number;
+}
+
+/**
+ * Result of scanning one session file: the extracted user prompts (in file
+ * order) plus `skippedLines`, the number of gate-passing lines whose JSON
+ * could not be parsed. Parse failures are counted, never fatal.
+ */
+export interface FileScanResult {
+  prompts: ExtractedPrompt[];
+  skippedLines: number;
+}
+
+/**
+ * Maximum extracted prompt length in UTF-16 code units (`text.length`). A
+ * prompt strictly greater than this is skipped; at the maximum it still
+ * extracts. The skip is uniform and silent (design §D1).
+ */
+export const MAX_PROMPT_CHARS = 16384;
+
+/**
+ * Cheap per-line substring prefilter literal. PREFILTER ONLY: a miss means
+ * the line is never parsed; the parsed extraction rule below is the only
+ * membership authority.
+ */
+const USER_ROLE_LITERAL = '"role":"user"';
+
+/** Defensive field-access shapes for session JSONL values. */
+interface SessionFields {
+  type?: unknown;
+  version?: unknown;
+  timestamp?: unknown;
+  message?: unknown;
+}
+
+interface MessageFields {
+  role?: unknown;
+  content?: unknown;
+  timestamp?: unknown;
+}
+
+/**
+ * Validate the line-1 session header. A file is admitted only when the
+ * header parses, carries type "session", and a numeric version ≤ 3
+ * (format v3; legacy v1/v2 tolerated). Mirrors pi's loadEntriesFromFile
+ * tolerance: any miss yields an empty scan, never a throw. Returns the
+ * header timestamp in ms, or NaN when absent or unparseable.
+ */
+function parseHeader(line: string): number | null {
+  let header: unknown;
+  try {
+    header = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (header == null || typeof header !== "object") return null;
+  const fields = header as SessionFields;
+  if (fields.type !== "session") return null;
+  if (typeof fields.version !== "number" || !(fields.version <= 3)) {
+    return null;
+  }
+  return typeof fields.timestamp === "string"
+    ? Date.parse(fields.timestamp)
+    : NaN;
+}
+
+/**
+ * Extract the prompt text from a user message's content: plain string
+ * content passes through as-is; block arrays join their text blocks with a
+ * single space and trim the assembly (upstream extractTextContent rule,
+ * design §D1) — images and other block types are ignored, and zero text
+ * blocks yield no prompt. Returns null when no prompt text exists.
+ */
+function extractText(content: unknown): string | null {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return null;
+  const parts: string[] = [];
+  for (const block of content) {
+    if (
+      block != null &&
+      typeof block === "object" &&
+      (block as SessionFields).type === "text" &&
+      typeof (block as { text?: unknown }).text === "string"
+    ) {
+      parts.push((block as { text: string }).text);
+    }
+  }
+  if (parts.length === 0) return null;
+  return parts.join(" ").trim();
+}
+
+/**
+ * Resolve a prompt's ordering timestamp: message ms-epoch, then entry ISO,
+ * then header ISO, then the file mtime. Every hop is NaN-tolerant; ordering
+ * data is never worth a throw.
+ */
+function resolveTimestamp(
+  entry: SessionFields,
+  message: MessageFields,
+  headerTs: number,
+  filePath: string,
+): number {
+  if (
+    typeof message.timestamp === "number" &&
+    Number.isFinite(message.timestamp)
+  ) {
+    return message.timestamp;
+  }
+  if (typeof entry.timestamp === "string") {
+    const parsed = Date.parse(entry.timestamp);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  if (!Number.isNaN(headerTs)) return headerTs;
+  try {
+    const mtimeMs = fs.statSync(filePath).mtimeMs;
+    if (!Number.isNaN(mtimeMs)) return mtimeMs;
+  } catch {
+    // The file vanished between read and stat — leave the NaN residue.
+  }
+  return NaN;
+}
+
+/**
+ * Extract every user prompt from one pi session transcript file.
+ *
+ * Pipeline (design §C): line-1 header admission gate; per line the cheap
+ * USER_ROLE_LITERAL substring gate as a PREFILTER ONLY (gate misses are
+ * never parsed); JSON.parse with a counted skip on throw; then the parsed
+ * extraction rule (entry type "message" AND user role) as the only
+ * membership authority. Whitespace-only text is skipped silently, and text
+ * above MAX_PROMPT_CHARS skips uniformly. UI-free and fs-only: data-path
+ * errors degrade to empty or partial results and never throw.
+ */
+export function extractPromptsFromFile(filePath: string): FileScanResult {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch {
+    return { prompts: [], skippedLines: 0 };
+  }
+
+  const lines = raw.split("\n");
+  const headerTs = parseHeader(lines[0]);
+  if (headerTs === null) return { prompts: [], skippedLines: 0 };
+
+  const prompts: ExtractedPrompt[] = [];
+  let skippedLines = 0;
+
+  for (let index = 1; index < lines.length; index++) {
+    const line = lines[index];
+    // Prefilter: a miss never reaches JSON.parse.
+    if (!line.includes(USER_ROLE_LITERAL)) continue;
+
+    let entry: unknown;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      skippedLines++;
+      continue;
+    }
+    if (entry == null || typeof entry !== "object") continue;
+
+    const record = entry as SessionFields;
+    if (record.type !== "message") continue;
+    if (record.message == null || typeof record.message !== "object") continue;
+    const message = record.message as MessageFields;
+    if (message.role !== "user") continue;
+
+    const text = extractText(message.content);
+    if (text === null || text.trim() === "") continue; // silent, not counted
+    if (text.length > MAX_PROMPT_CHARS) continue; // uniform silent length skip
+
+    prompts.push({
+      text,
+      ts: resolveTimestamp(record, message, headerTs, filePath),
+    });
+  }
+
+  return { prompts, skippedLines };
+}
+
+/**
+ * One-level scan rule (C1): list the top-level `*.jsonl` session files of
+ * every encoded-cwd directory under the pi sessions root. Only DIRECTORIES
+ * at the root are entered (stray root-level files are skipped) and only
+ * their top-level jsonl files are candidates — nested subagent payloads
+ * (`run-N/session.jsonl`) and `subagent-artifacts/` subtrees are directories
+ * and are never descended. An unreadable root yields an empty list and a
+ * directory whose readdir fails is skipped — never fatal. Returns sorted
+ * absolute paths for deterministic scan order. Mirrors pi's non-recursive
+ * listSessionsFromDir (session-manager.ts:822-826, read-only).
+ */
+export function listSessionFiles(sessionsRoot: string): string[] {
+  let rootEntries: fs.Dirent[];
+  try {
+    rootEntries = fs.readdirSync(sessionsRoot, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const files: string[] = [];
+  for (const rootEntry of rootEntries) {
+    if (!rootEntry.isDirectory()) continue;
+    const dirPath = path.join(sessionsRoot, rootEntry.name);
+    let children: fs.Dirent[];
+    try {
+      children = fs.readdirSync(dirPath, { withFileTypes: true });
+    } catch {
+      continue; // one unreadable directory skips itself, never fatal
+    }
+    for (const child of children) {
+      if (child.isFile() && child.name.endsWith(".jsonl")) {
+        files.push(path.join(dirPath, child.name));
+      }
+    }
+  }
+  return files.sort();
+}

--- a/extensions/history/store.ts
+++ b/extensions/history/store.ts
@@ -116,13 +116,14 @@ export function ensureRegistryEntry(
   const data = readRegistry(root);
   if (data[hash] === cwd) return { hash, created: false };
   if (data[hash] !== undefined) {
-    // Collision: lengthen this entry's key; readers resolve labels by exact
-    // key match so both mappings remain addressable.
-    const longHash = projectHashLong(cwd);
-    delete data[hash];
-    data[longHash] = cwd;
+    // Collision: re-key the EXISTING occupant at 24 hash chars so both
+    // identities coexist; the incoming cwd keeps the short hash — the
+    // key shape projectDir/sessionFilePath/drains derive.
+    const existing = data[hash];
+    data[projectHashLong(existing)] = existing;
+    data[hash] = cwd;
     writeRegistryAtomic(root, data);
-    return { hash: longHash, created: true };
+    return { hash, created: true };
   }
   data[hash] = cwd;
   writeRegistryAtomic(root, data);

--- a/extensions/history/store.ts
+++ b/extensions/history/store.ts
@@ -1,0 +1,800 @@
+// Consolidated multi-concurrency store (v2): paths, registry, session
+// writer, scope drains/deletes, legacy migration, bootstrap, GC.
+// Formerly store-paths.ts + registry.ts + multi-store.ts (+ v1 primitives).
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { loadHiddenPrompts } from "./hide-prompts.ts";
+import { loadSharedHistory } from "./load-shared-history.ts";
+import {
+  extractPromptsFromFile,
+  listSessionFiles,
+  type ExtractedPrompt,
+} from "./session-scan.ts";
+
+// ===========================================================================
+// Paths (formerly store-paths.ts)
+// ===========================================================================
+
+/**
+ * Project identity for the multi-concurrency store (design v2).
+ *
+ * The cwd is canonicalized through realpath — the same resolution pi's
+ * session-manager applies — so symlinked or differently-spelled paths to one
+ * project merge into a single identity. A failed resolution (deleted cwd)
+ * falls back to hashing the raw string: identity degrades, never throws.
+ */
+export function projectHash(cwd: string): string {
+  let canonical = cwd;
+  try {
+    canonical = fs.realpathSync(cwd);
+  } catch {
+    // fall back to the raw path
+  }
+  return createHash("sha256").update(canonical).digest("hex").slice(0, 16);
+}
+
+/** The project's directory under the store root. */
+export function projectDir(root: string, cwd: string): string {
+  return path.join(root, "projects", projectHash(cwd));
+}
+
+/** The capture file owned by one pi instance (per session/process). */
+export function sessionFilePath(
+  root: string,
+  cwd: string,
+  instanceId: string,
+): string {
+  return path.join(projectDir(root, cwd), `${instanceId}.jsonl`);
+}
+
+/** The rebuildable bootstrap output for a project. */
+export function seedFilePath(root: string, cwd: string): string {
+  return path.join(projectDir(root, cwd), "seed.jsonl");
+}
+
+/** The one-time legacy/global seed (never GC'd). */
+export function globalSeedPath(root: string): string {
+  return path.join(root, "history-global.jsonl");
+}
+
+/** Advisory hash → cwd map for display labels. */
+export function registryPath(root: string): string {
+  return path.join(root, "registry.json");
+}
+
+// ===========================================================================
+// Registry (formerly registry.ts)
+// ===========================================================================
+
+export interface RegistryEntryResult {
+  hash: string;
+  created: boolean;
+}
+
+type RegistryData = Record<string, string>;
+
+function readRegistry(root: string): RegistryData {
+  try {
+    const raw = fs.readFileSync(registryPath(root), "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    const out: RegistryData = {};
+    for (const [key, value] of Object.entries(
+      parsed as Record<string, unknown>,
+    )) {
+      if (typeof value === "string") out[key] = value;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function writeRegistryAtomic(root: string, data: RegistryData): void {
+  const target = registryPath(root);
+  const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+  fs.mkdirSync(root, { recursive: true });
+  fs.writeFileSync(tmp, JSON.stringify(data, null, 2) + "\n", "utf8");
+  fs.renameSync(tmp, target);
+}
+
+/**
+ * Ensure the advisory registry maps this project's hash to its cwd.
+ * Idempotent: an existing identical entry writes nothing. A hash mapped to a
+ * DIFFERENT cwd is a (practically unreachable) collision — the entry is
+ * re-keyed at 24 hash chars so both identities coexist.
+ */
+export function ensureRegistryEntry(
+  root: string,
+  cwd: string,
+): RegistryEntryResult {
+  const hash = projectHash(cwd);
+  const data = readRegistry(root);
+  if (data[hash] === cwd) return { hash, created: false };
+  if (data[hash] !== undefined) {
+    // Collision: lengthen this entry's key; readers resolve labels by exact
+    // key match so both mappings remain addressable.
+    const longHash = projectHashLong(cwd);
+    delete data[hash];
+    data[longHash] = cwd;
+    writeRegistryAtomic(root, data);
+    return { hash: longHash, created: true };
+  }
+  data[hash] = cwd;
+  writeRegistryAtomic(root, data);
+  return { hash, created: true };
+}
+
+/** Display lookup: hash → cwd, null when unknown or the file is absent. */
+export function lookupCwd(root: string, hash: string): string | null {
+  return readRegistry(root)[hash] ?? null;
+}
+
+function projectHashLong(cwd: string): string {
+  // Reuse the same canonicalization as projectHash but keep 24 chars.
+  let canonical = cwd;
+  try {
+    canonical = fs.realpathSync(cwd);
+  } catch {
+    // fall back to the raw path
+  }
+  return createHash("sha256").update(canonical).digest("hex").slice(0, 24);
+}
+
+// ===========================================================================
+// Entry primitives (from v1 history-store.ts)
+// ===========================================================================
+
+/** One line of `editor-history.jsonl`. */
+export interface StoreEntry {
+  /** Schema version; 1 when absent in the source line. */
+  v: number;
+  text: string;
+  /** Capture epoch-ms; optional, line order is authoritative for recency. */
+  ts?: number;
+}
+
+
+/**
+ * Parse one JSONL line. Returns null for malformed lines (bad JSON,
+ * non-string or whitespace-only text) so callers can skip them; a torn
+ * last line from a crash is handled the same way.
+ */
+export function parseStoreLine(raw: string): StoreEntry | null {
+  if (raw.length === 0) return null;
+  try {
+    const value: unknown = JSON.parse(raw);
+    if (!value || typeof value !== "object") return null;
+    const record = value as { v?: unknown; text?: unknown; ts?: unknown };
+    if (typeof record.text !== "string") return null;
+    if (record.text.trim().length === 0) return null;
+    const entry: StoreEntry = { v: 1, text: record.text };
+    if (typeof record.v === "number" && Number.isFinite(record.v)) {
+      entry.v = record.v;
+    }
+    if (typeof record.ts === "number" && Number.isFinite(record.ts)) {
+      entry.ts = record.ts;
+    }
+    return entry;
+  } catch {
+    return null;
+  }
+}
+
+
+// ===========================================================================
+// Multi-store (formerly multi-store.ts)
+// ===========================================================================
+
+
+/** Mutable state of ONE pi instance's exclusive capture file. */
+export interface SessionWriterState {
+  filePath: string;
+  /** Logical line count of this instance's file. */
+  lineCount: number;
+}
+
+/** Command-like prompts (`/name ...`) are UI commands, not prompts. */
+function isLikelyCommand(text: string): boolean {
+  return /^\/[A-Za-z]/.test(text.trim());
+}
+
+function serializeEntry(entry: StoreEntry): string {
+  const out: { v: number; text: string; ts?: number } = {
+    v: entry.v,
+    text: entry.text,
+  };
+  if (entry.ts !== undefined) out.ts = entry.ts;
+  return JSON.stringify(out);
+}
+
+/**
+ * Open the writer for this pi instance. The file is created LAZILY by the
+ * first capture — starting pi must not litter empty files. Only this
+ * instance ever appends here (design v2: zero shared writes).
+ */
+export function openSessionWriter(
+  root: string,
+  cwd: string,
+  instanceId: string,
+): SessionWriterState {
+  return {
+    filePath: sessionFilePath(root, cwd, instanceId),
+    lineCount: 0,
+  };
+}
+
+/**
+ * Append one prompt line to the instance's own file (write-through).
+ * Skips empty/whitespace-only and command-like prompts.
+ */
+export function appendSessionCapture(
+  state: SessionWriterState,
+  text: string,
+  ts?: number,
+): void {
+  if (typeof text !== "string" || text.trim().length === 0) return;
+  if (isLikelyCommand(text)) return;
+
+  const entry: StoreEntry = { v: 1, text };
+  if (ts !== undefined) entry.ts = ts;
+  fs.mkdirSync(path.dirname(state.filePath), { recursive: true });
+  fs.appendFileSync(state.filePath, serializeEntry(entry) + "\n", "utf8");
+  state.lineCount += 1;
+}
+
+
+// ---------------------------------------------------------------------------
+// Multi-file reader (design v2: k-way backward merge)
+// ---------------------------------------------------------------------------
+
+/** UI-level prompt identity: whitespace-collapsed, case-insensitive. */
+function promptKey(text: string): string {
+  return text.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function fileMtimeMs(file: string): number {
+  try {
+    return fs.statSync(file).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+function listProjectFiles(dir: string): string[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((e) => e.isFile() && e.name.endsWith(".jsonl"))
+    .map((e) => path.join(dir, e.name))
+    .sort((a, b) => fileMtimeMs(b) - fileMtimeMs(a));
+}
+
+/**
+ * Drain one file's prompts newest-first (reverse file order). Malformed
+ * lines are skipped; entries are yielded with their source file so the
+ * k-way merge can interleave across files.
+ */
+function* fileEntriesBackward(
+  file: string,
+): Generator<{ text: string; file: string; seq: number }> {
+  let raw = "";
+  try {
+    raw = fs.readFileSync(file, "utf8");
+  } catch {
+    return;
+  }
+  const lines = raw.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const parsed = parseStoreLine(lines[i]);
+    if (parsed) yield { text: parsed.text, file, seq: i };
+  }
+}
+
+/**
+ * k-way backward merge: files sorted by mtime (newest first) contribute in
+ * round-robin order; inside a file, newest lines first. Round-robin across
+ * mtime-ordered files approximates global recency without line-level ts
+ * comparison and keeps interleaving deterministic.
+ */
+/** Read one file's valid entries (chronological). */
+function readFileEntries(file: string): StoreEntry[] {
+  let raw = "";
+  try {
+    raw = fs.readFileSync(file, "utf8");
+  } catch {
+    return [];
+  }
+  const entries: StoreEntry[] = [];
+  for (const lineText of raw.split("\n")) {
+    const parsed = parseStoreLine(lineText);
+    if (parsed) entries.push(parsed);
+  }
+  return entries;
+}
+
+/**
+ * Sort key = the newest entry ts in the file (fallback: file mtime).
+ * ts-based keys are STABLE under atomic rewrites (deletes/compaction
+ * bump mtime, which used to reshuffle the drain order).
+ */
+function fileSortKey(file: string, entries: StoreEntry[]): number {
+  let maxTs = 0;
+  for (const entry of entries) {
+    if (entry.ts !== undefined && entry.ts > maxTs) maxTs = entry.ts;
+  }
+  return maxTs > 0 ? maxTs : fileMtimeMs(file);
+}
+
+/**
+ * Sequential backward drain over PRE-SORTED files: each file fully,
+ * newest-line-first, deduped by UI-level identity, capped at `limit`.
+ */
+function drainFiles(
+  files: string[],
+  limit: number,
+  hidden: Set<string> = new Set(),
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const file of files) {
+    const entries = readFileEntries(file);
+    for (let i = entries.length - 1; i >= 0; i--) {
+      const key = promptKey(entries[i].text);
+      if (seen.has(key)) continue;
+      if (hidden.size > 0 && hidden.has(promptDedupKeyOf(entries[i].text))) {
+        continue;
+      }
+      seen.add(key);
+      out.push(entries[i].text);
+      if (out.length >= limit) return out;
+    }
+  }
+  return out;
+}
+
+/** Sort files for draining: ts-keyed, newest first, empty files dropped. */
+function sortFilesForDrain(files: string[]): string[] {
+  return files
+    .map((file) => ({ file, entries: readFileEntries(file) }))
+    .filter((f) => f.entries.length > 0)
+    .sort(
+      (a, b) =>
+        fileSortKey(b.file, b.entries) - fileSortKey(a.file, a.entries),
+    )
+    .map((f) => f.file);
+}
+
+/**
+ * Drain the PROJECT scope: all .jsonl files in the project dir (seed.jsonl
+ * included), mtime-newest-first, deduped, capped at `limit` (default 1000).
+ */
+export function drainProject(
+  root: string,
+  cwd: string,
+  limit: number = 1000,
+  stateDir?: string,
+): string[] {
+  return drainFiles(
+    sortFilesForDrain(listProjectFiles(path.join(root, "projects", projectHash(cwd)))),
+    limit,
+    stateDir ? loadHiddenPrompts(stateDir) : new Set<string>(),
+  );
+}
+
+/**
+ * Drain the GLOBAL scope: the legacy global seed (newest single source)
+ * plus every project dir's files, mtime-newest-first, deduped, capped.
+ */
+export function drainGlobal(
+  root: string,
+  limit: number = 1000,
+  stateDir?: string,
+): string[] {
+  const files: string[] = [];
+  const globalSeed = globalSeedPath(root);
+
+  let projectDirs: fs.Dirent[];
+  try {
+    projectDirs = fs.readdirSync(path.join(root, "projects"), {
+      withFileTypes: true,
+    });
+  } catch {
+    projectDirs = [];
+  }
+  for (const dirEntry of projectDirs) {
+    if (!dirEntry.isDirectory()) continue;
+    files.push(
+      ...listProjectFiles(path.join(root, "projects", dirEntry.name)),
+    );
+  }
+  const sorted = sortFilesForDrain(files);
+  if (fs.existsSync(globalSeed)) sorted.push(globalSeed); // legacy last
+  return drainFiles(
+    sorted,
+    limit,
+    stateDir ? loadHiddenPrompts(stateDir) : new Set<string>(),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scope delete (design v2)
+// ---------------------------------------------------------------------------
+
+interface SweepResult {
+  filesAffected: number;
+  removed: number;
+}
+
+/**
+ * Remove every line whose prompt identity matches `text` from each file in
+ * `files`, one atomic rewrite (tmp + rename) per affected file. Files whose
+ * every line matched are kept as empty files (never removed — the instance
+ * owning a session file may still append to it).
+ */
+function sweepFiles(files: string[], text: string): SweepResult {
+  const key = promptKey(text);
+  let filesAffected = 0;
+  let removed = 0;
+  for (const file of files) {
+    let raw = "";
+    try {
+      raw = fs.readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    const kept: string[] = [];
+    let fileRemoved = 0;
+    for (const lineText of raw.split("\n")) {
+      const parsed = parseStoreLine(lineText);
+      if (!parsed) continue;
+      if (promptKey(parsed.text) === key) {
+        fileRemoved += 1;
+      } else {
+        kept.push(JSON.stringify(parsed));
+      }
+    }
+    if (fileRemoved === 0) continue;
+    const tmp = `${file}.tmp-${process.pid}-${Date.now()}`;
+    fs.writeFileSync(tmp, kept.length > 0 ? kept.join("\n") + "\n" : "", "utf8");
+    fs.renameSync(tmp, file);
+    filesAffected += 1;
+    removed += fileRemoved;
+  }
+  return { filesAffected, removed };
+}
+
+/** Delete every copy of a prompt from the CURRENT project's scope. */
+export function deleteFromProject(
+  root: string,
+  cwd: string,
+  text: string,
+): SweepResult {
+  return sweepFiles(
+    listProjectFiles(path.join(root, "projects", projectHash(cwd))),
+    text,
+  );
+}
+
+/** Delete every copy of a prompt from the GLOBAL scope (all projects + seed). */
+export function deleteFromGlobal(root: string, text: string): SweepResult {
+  const files: string[] = [];
+  const globalSeed = globalSeedPath(root);
+  if (fs.existsSync(globalSeed)) files.push(globalSeed);
+  let projectDirs: fs.Dirent[];
+  try {
+    projectDirs = fs.readdirSync(path.join(root, "projects"), {
+      withFileTypes: true,
+    });
+  } catch {
+    projectDirs = [];
+  }
+  for (const dirEntry of projectDirs) {
+    if (!dirEntry.isDirectory()) continue;
+    files.push(
+      ...listProjectFiles(path.join(root, "projects", dirEntry.name)),
+    );
+  }
+  return sweepFiles(files, text);
+}
+
+// ---------------------------------------------------------------------------
+// Legacy migration (design v2: one-time, gated)
+// ---------------------------------------------------------------------------
+
+export interface MigrationResult {
+  migrated: number;
+  ran: boolean;
+}
+
+function readValidLines(file: string): StoreEntry[] {
+  try {
+    const raw = fs.readFileSync(file, "utf8");
+    const entries: StoreEntry[] = [];
+    for (const lineText of raw.split("\n")) {
+      const parsed = parseStoreLine(lineText);
+      if (parsed) entries.push(parsed);
+    }
+    return entries;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * One-time migration from the v1 stores into the v2 global seed:
+ * - `~/.pi/agent/editor-history.jsonl` (v1 single-file store)
+ * - `~/.pi/agent/editor-history.json` (pre-v1 array, newest-first)
+ * Content lands in `pi-history/history-global.jsonl` chronologically; each
+ * source is renamed `.imported`, never deleted. Gated: an existing global
+ * seed means migration already ran.
+ */
+export function migrateLegacyStores(
+  root: string,
+  agentDir: string,
+): MigrationResult {
+  const seed = globalSeedPath(root);
+  if (fs.existsSync(seed)) return { migrated: 0, ran: false };
+
+  const collected: StoreEntry[] = [];
+
+  // Pre-v1 array (newest-first) → reverse to chronological.
+  const legacyArray = path.join(agentDir, "editor-history.json");
+  if (fs.existsSync(legacyArray)) {
+    const texts = loadSharedHistory(legacyArray);
+    if (texts.length > 0) {
+      for (let i = texts.length - 1; i >= 0; i--) {
+        collected.push({ v: 1, text: texts[i] });
+      }
+    }
+    try {
+      fs.renameSync(legacyArray, `${legacyArray}.imported`);
+    } catch {
+      // The seed write below is the source of truth; rename failure is benign.
+    }
+  }
+
+  // v1 single-file store — already chronological.
+  const v1File = path.join(agentDir, "editor-history.jsonl");
+  if (fs.existsSync(v1File)) {
+    collected.push(...readValidLines(v1File));
+    try {
+      fs.renameSync(v1File, `${v1File}.imported`);
+    } catch {
+      // benign
+    }
+  }
+
+  if (collected.length === 0) return { migrated: 0, ran: false };
+
+  fs.mkdirSync(path.dirname(seed), { recursive: true });
+  const tmp = `${seed}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(
+    tmp,
+    collected.map((e) => JSON.stringify(e)).join("\n") + "\n",
+    "utf8",
+  );
+  fs.renameSync(tmp, seed);
+  return { migrated: collected.length, ran: true };
+}
+
+// ---------------------------------------------------------------------------
+// Project bootstrap (design v2: seed.jsonl)
+// ---------------------------------------------------------------------------
+
+export interface SeedResult {
+  seeded: number;
+  ran: boolean;
+}
+
+/**
+ * Seed `projects/<hash>/seed.jsonl` from the project's pi transcripts when
+ * the project dir holds fewer than `target` entries. Existing session files
+ * are counted; their prompts are NOT re-seeded (dedupe by UI-level key).
+ * The seed is a rebuildable cache — rewritten only when the dir is empty.
+ */
+/** Tombstone key - byte-compatible with hide-prompts' promptDedupKey. */
+function promptDedupKeyOf(text: string): string {
+  return text.replace(/\s+/g, " ").trim().slice(0, 120).toLowerCase();
+}
+
+export function bootstrapProjectSeed(
+  root: string,
+  cwd: string,
+  sessionsRoot: string,
+  target: number,
+  stateDir?: string,
+): SeedResult {
+  const dir = path.join(root, "projects", projectHash(cwd));
+
+  // Count existing entries and collect their identities.
+  const existingKeys = new Set<string>();
+  let existingCount = 0;
+  for (const file of listProjectFiles(dir)) {
+    let raw = "";
+    try {
+      raw = fs.readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    for (const lineText of raw.split("\n")) {
+      const parsed = parseStoreLine(lineText);
+      if (parsed) {
+        existingCount += 1;
+        existingKeys.add(promptKey(parsed.text));
+      }
+    }
+  }
+  if (existingCount >= target) return { seeded: 0, ran: false };
+  // The seed is written ONCE: an existing seed is never regenerated, so a
+  // deleted prompt cannot be resurrected from transcripts on a new session.
+  if (fs.existsSync(seedFilePath(root, cwd))) {
+    return { seeded: 0, ran: false };
+  }
+  // Tombstones (user deletions) suppress transcript prompts from seeding.
+  const hidden = stateDir ? loadHiddenPrompts(stateDir) : new Set<string>();
+
+  // Scan transcripts: session files of THIS project's dir, newest first.
+  let files: string[] = [];
+  try {
+    const dirName = cwd
+      .replace(/^[/\\]/, "")
+      .replace(/[/\\:]/g, "-");
+    files = listSessionFiles(sessionsRoot).filter((file) =>
+      file.includes(`${path.sep}--${dirName}--${path.sep}`),
+    );
+  } catch {
+    return { seeded: 0, ran: false };
+  }
+  files.sort((a, b) => fileMtimeMs(b) - fileMtimeMs(a));
+
+  const collected: StoreEntry[] = [];
+  outer: for (const file of files) {
+    let prompts: ExtractedPrompt[] = [];
+    try {
+      prompts = extractPromptsFromFile(file).prompts;
+    } catch {
+      continue;
+    }
+    for (let i = prompts.length - 1; i >= 0; i--) {
+      const text = prompts[i].text;
+      if (/^\/[A-Za-z]/.test(text.trim())) continue;
+      if (hidden.size > 0 && hidden.has(promptDedupKeyOf(text))) continue;
+      const key = promptKey(text);
+      if (existingKeys.has(key)) continue;
+      existingKeys.add(key);
+      const entry: StoreEntry = { v: 1, text };
+      if (Number.isFinite(prompts[i].ts)) entry.ts = prompts[i].ts;
+      collected.push(entry);
+      if (collected.length >= target - existingCount) break outer;
+    }
+  }
+  if (collected.length === 0) return { seeded: 0, ran: false };
+
+  collected.reverse(); // chronological (oldest first)
+  const seed = seedFilePath(root, cwd);
+  fs.mkdirSync(path.dirname(seed), { recursive: true });
+  const tmp = `${seed}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(
+    tmp,
+    collected.map((e) => JSON.stringify(e)).join("\n") + "\n",
+    "utf8",
+  );
+  fs.renameSync(tmp, seed);
+  return { seeded: collected.length, ran: true };
+}
+
+// ---------------------------------------------------------------------------
+// GC / compaction (design v2)
+// ---------------------------------------------------------------------------
+
+const GC_FILE_THRESHOLD = 50;
+const GC_LINE_THRESHOLD = 5000;
+const GC_KEEP_NEWEST = 10;
+
+export interface GcResult {
+  compacted: boolean;
+  merged: number;
+}
+/**
+ * Threshold check + compaction entry point (called at shutdown and at
+ * selector close). Compacts when a project dir holds more than
+ * GC_FILE_THRESHOLD files or GC_LINE_THRESHOLD total lines.
+ */
+export function gcProjectDir(
+  root: string,
+  cwd: string,
+  opts: {
+    fileThreshold?: number;
+    lineThreshold?: number;
+    keepNewest?: number;
+  } = {},
+): GcResult {
+  const fileThreshold = opts.fileThreshold ?? GC_FILE_THRESHOLD;
+  const lineThreshold = opts.lineThreshold ?? GC_LINE_THRESHOLD;
+  const keepNewest = opts.keepNewest ?? GC_KEEP_NEWEST;
+  const dir = path.join(root, "projects", projectHash(cwd));
+  const files = listProjectFiles(dir); // mtime-desc
+  if (files.length === 0) return { compacted: false, merged: 0 };
+
+  let totalLines = 0;
+  for (const file of files) {
+    try {
+      totalLines += fs
+        .readFileSync(file, "utf8")
+        .split("\n")
+        .filter((l) => l.trim().length > 0).length;
+    } catch {
+      // unreadable file: skip counting
+    }
+  }
+  if (files.length <= fileThreshold && totalLines <= lineThreshold) {
+    return { compacted: false, merged: 0 };
+  }
+  return compactFiles(files, keepNewest);
+}
+
+/**
+ * Merge all but the newest GC_KEEP_NEWEST files into one
+ * `compact-<ts>.jsonl` (chronological within the merged content). One
+ * atomic write; the originals are removed only after the compact file
+ * lands. Readers see either the old set or the compacted set.
+ */
+export function compactProjectDir(
+  root: string,
+  cwd: string,
+  opts: { keepNewest?: number } = {},
+): GcResult {
+  const dir = path.join(root, "projects", projectHash(cwd));
+  return compactFiles(
+    listProjectFiles(dir),
+    opts.keepNewest ?? GC_KEEP_NEWEST,
+  );
+}
+
+function compactFiles(
+  filesMtimeDesc: string[],
+  keepNewest: number,
+): GcResult {
+  if (filesMtimeDesc.length <= keepNewest) {
+    return { compacted: false, merged: 0 };
+  }
+  const toMerge = filesMtimeDesc.slice(keepNewest); // oldest tail
+  const mergedLines: string[] = [];
+  for (const file of toMerge) {
+    try {
+      const raw = fs.readFileSync(file, "utf8");
+      for (const lineText of raw.split("\n")) {
+        const parsed = parseStoreLine(lineText);
+        if (parsed) mergedLines.push(JSON.stringify(parsed));
+      }
+    } catch {
+      // unreadable file: skip its content, still remove nothing
+      continue;
+    }
+  }
+  if (mergedLines.length === 0) return { compacted: false, merged: 0 };
+
+  const dir = path.dirname(toMerge[0]);
+  const compact = path.join(dir, `compact-${Date.now()}.jsonl`);
+  const tmp = `${compact}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(tmp, mergedLines.join("\n") + "\n", "utf8");
+  fs.renameSync(tmp, compact);
+  for (const file of toMerge) {
+    try {
+      fs.rmSync(file);
+    } catch {
+      // a surviving original is harmless (readers dedupe by identity)
+    }
+  }
+  return { compacted: true, merged: toMerge.length };
+}
+


### PR DESCRIPTION
Closes #818

## PR Type

- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Adds `extensions/history/`, a Pi extension that records every delivered prompt write-through to an append-only, per-Pi-instance JSONL store under `~/.pi/agent/history/` (zero shared writes between concurrent processes) and opens a searchable, cross-session prompt-history selector via `/history` or `ctrl+shift+r`.
- The selector is a bottom-anchored, fixed 30-row TUI overlay: search-as-you-type (multi-word AND substring, case-insensitive, 10k cap), 10-row result list with position and lazy-window counters, word-wrapped 10-row preview pane with overflow range label, project/global scope toggle (`Tab`), and mouse-wheel regions for both list and preview.
- Full keyboard support: arrows, PgUp/PgDn, Home/End (End one-shot loads the full history), `Tab` scope toggle, `ctrl+shift+↑/↓` preview paging, `Esc` cancel; any other key falls through into the search input.
- Delete with tombstones (`ctrl+shift+backspace`): editor-sourced prompts are swept from the store; session-sourced ones are tombstoned in `hidden.json` so transcript re-seeding cannot resurrect them; hide-write failures surface a warning toast.
- Cold start does a one-time legacy `editor-history.json(l)` migration and a one-time per-project seed (target 500) extracted from Pi session transcripts (read-only, format-gated); `session_shutdown` GC compacts the oldest tail past thresholds (50 files / 5000 lines), keeping the 10 newest files.
- Multi-concurrency safe by design: per-instance UUID capture files, newest-first ordering stable under atomic rewrites (file ts with mtime fallback), keep-first dedupe by normalized identity, same-directory tmp+rename for every destructive write, advisory `registry.json` hash→cwd map, torn-line-tolerant JSONL parsing.

## Changes

| File | Change |
|------|--------|
| `extensions/history/index.ts` | Extension entry: `/history` command, `ctrl+shift+r` shortcut, `before_agent_start` capture, `session_shutdown` GC, `tool_call` overlay dismissal, and the full TUI selector (search, list, preview, scope radio, keybindings, mouse wheel, fixed geometry). |
| `extensions/history/store.ts` | Multi-concurrency JSONL store v2: path builders, advisory registry, per-instance session writer, drain/read machinery with dedupe and recency ordering, scope deletes, legacy migration, transcript seed, GC compaction. |
| `extensions/history/selector-helpers.ts` | Pure selector logic (no I/O): record types, index math, dedup keys, lazy-window growth functions, delete planner, filter semantics. |
| `extensions/history/session-scan.ts` | Read-only transcript extraction: header admission gate, user-role prefilter, text extraction, timestamp fallback chain, one-level session listing. |
| `extensions/history/session-index.ts` | Persisted transcript index (`prompt-index.json`): fail-open load, atomic persist, budgeted refresh, chunked background build. |
| `extensions/history/merge-history.ts` | Combined editor+session history loader with tombstone pre-filter. |
| `extensions/history/hide-prompts.ts` | Tombstone store (`hidden.json`): fail-open load, atomic sorted-key writes, never throws. |
| `extensions/history/load-shared-history.ts` | Reader for the legacy pre-v1 JSON-array `editor-history.json`. |
| `extensions/history/atomic-write.ts` | Shared atomic JSON writer: same-directory tmp + rename, returns boolean, never throws. |

## Test Plan

- [x] Syntax gate: `node --experimental-strip-types --check` passes on all 9 extension files.
- [x] Exercised in live Pi sessions on the author's machine during development: store layout (`projects/<hash>/<instance>.jsonl`, `registry.json`, `hidden.json`, `history-global.jsonl`) is in active use, including tombstone deletes.
- [x] CI suite (`pnpm test`, runtime-modules check, package verification, packed-package test) runs on this PR via GitHub Actions.

## Contributor Checklist

- [x] Linked an approved issue (#818)
- [ ] Added exactly one `type:*` label (requires maintainer label permission — please add `type:feature`; `size:exception` may also apply, the diff is ~2.9k lines)
- [x] No shell scripts modified (shellcheck N/A)
- [x] Extension load-tested in a target agent
- [ ] Docs updated (README package-contents row intentionally not included to keep this PR scoped to the extension directory and avoid conflicts with #806; happy to add on request)
- [x] Conventional commit format (`feat(extensions): ...`)
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added prompt history access through `Ctrl+Shift+R` and the `/history` command.
  - Automatically preserves delivered prompts across sessions and projects.
  - Search history with multi-word filtering, previews, keyboard navigation, paging, and mouse scrolling.
  - Switch between project and global history.
  - Delete prompts from history and suppress them from future results.
  - Supports existing history data and progressively loads results.
  - Remains available despite incomplete, unreadable, or partially corrupted history data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
---

## ⚠️ Tracker PR — split into 6 review slices (do not merge here)

Split per the maintainer's request ([comment](https://github.com/Gentleman-Programming/gentle-shell/pull/819#issuecomment-5697271486)). Review the child PRs in the fork — each is independently reviewable with its own tests and matches the suggested sequence 1:1. This PR stays **draft** and fast-forwards to the chain tip; it becomes the merge candidate once all children are approved.

| # | Child PR (carolitascl/gentle-shell) | Suggested-sequence requirement |
|---|---|---|
| 1 | [carolitascl/gentle-shell#1](https://github.com/carolitascl/gentle-shell/pull/1) | Per-instance JSONL store, project identity, storage/concurrency tests |
| 2 | [carolitascl/gentle-shell#2](https://github.com/carolitascl/gentle-shell/pull/2) | Read, ordering, deduplication, project/global query APIs |
| 3 | [carolitascl/gentle-shell#3](https://github.com/carolitascl/gentle-shell/pull/3) | History selector TUI and command/shortcut wiring |
| 4 | [carolitascl/gentle-shell#4](https://github.com/carolitascl/gentle-shell/pull/4) | Transcript migration and seeding (dead session-indexing files removed — see PR body) |
| 5 | [carolitascl/gentle-shell#5](https://github.com/carolitascl/gentle-shell/pull/5) | Tombstones, deletion, and privacy semantics |
| 6 | [carolitascl/gentle-shell#6](https://github.com/carolitascl/gentle-shell/pull/6) | GC/compaction with active-writer and failure-path tests |

Full chain: **179/179** automated tests green (`node --experimental-strip-types --test tests/history-*.test.ts`), including the concurrency and recovery coverage required for persistence, migration, deletion, and compaction. The Copilot/CodeRabbit findings from the original combined PR are addressed in the owning slices.

### Autonomy
- [x] Each child PR has one deliverable scope and can be rolled back independently
- [x] Chain integration order: 1 → 2 → 3 → 4 → 5 → 6
