### PR TITLE
fix(extensions): fall back to ESM import when createRequire is intercepted

### DIFF
--- a/extensions/pi-pretty.ts
+++ b/extensions/pi-pretty.ts
@@ -11,12 +11,30 @@ const packageJsonPath = realpathSync(
 	fileURLToPath(new URL("../package.json", import.meta.url)),
 );
 const requireFromRealPackage = createRequire(packageJsonPath);
-const piPrettyModule = requireFromRealPackage("@heyhuynhgiabuu/pi-pretty");
 
-const piPrettyExtension =
-	typeof piPrettyModule === "function"
-		? piPrettyModule
-		: piPrettyModule.default;
+type PiPrettyExtensionFn = (pi: unknown, deps?: unknown) => unknown;
+
+function unwrapPiPrettyModule(piPrettyModule: unknown): PiPrettyExtensionFn {
+	const extension =
+		typeof piPrettyModule === "function"
+			? piPrettyModule
+			: (piPrettyModule as { default: unknown }).default;
+	if (typeof extension !== "function") {
+		throw new Error("pi-pretty did not export a usable extension function");
+	}
+	return extension as PiPrettyExtensionFn;
+}
+
+async function loadPiPrettyExtension(): Promise<PiPrettyExtensionFn> {
+	try {
+		return unwrapPiPrettyModule(requireFromRealPackage("@heyhuynhgiabuu/pi-pretty"));
+	} catch {
+		// Compiled Pi binaries intercept createRequire, so the package-name
+		// require fails even when the dependency is installed (gentle-pi#238).
+		// ESM import uses filesystem resolution and loads the same module.
+		return unwrapPiPrettyModule(await import("@heyhuynhgiabuu/pi-pretty"));
+	}
+}
 
 export default async function gentlePiPrettyExtension(pi: unknown, deps?: unknown): Promise<unknown> {
 	if (quietToolsEnabled()) {
@@ -25,5 +43,6 @@ export default async function gentlePiPrettyExtension(pi: unknown, deps?: unknow
 			PI_PRETTY_SUPPRESSED_TOOL_NAMES,
 		);
 	}
+	const piPrettyExtension = await loadPiPrettyExtension();
 	return piPrettyExtension(pi, deps);
 }


### PR DESCRIPTION
Closes #238

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- `extensions/pi-pretty.ts` no longer hard-fails when the Pi compiled binary intercepts `createRequire`: if the package-name `require` throws, it falls back to an ESM `import()` of the same installed dependency.
- Keeps the existing real-path `createRequire` behavior as the primary path (pnpm symlink installs keep working as before).
- No dependency, manifest, or packaging changes.

## Changes

| File | Change |
|------|--------|
| `extensions/pi-pretty.ts` | Lazy-load the pi-pretty module with try/require primary + ESM-import fallback; unwrap function-or-default interop in one helper |

## Test Plan

- [x] No shell scripts modified (shellcheck N/A)
- [x] Manually tested the affected functionality: `pi -p "hi"` from a repo that consumes gentle-pi as a linked package now starts with all extensions on Pi 0.85.1 (previously aborted with `Failed to load extension ... pi-pretty.ts ... ResolveMessage: Cannot find module '@heyhuynhgiabuu/pi-pretty'`); plain Node import of the wrapper also verified
- [x] Repo tests for the touched area pass: `tests/package-manifest.test.ts` + `tests/quiet-tool-rendering.test.ts` (95 pass, 0 fail)
- [ ] Full `pnpm test` left to CI

## Contributor Checklist

- [x] Linked issue #238 (`Closes #238`)
- [x] Added exactly one `type:*` label (`type:bug`, added after creation)
- [x] Ran relevant repo tests (see Test Plan)
- [x] Docs updated if behavior changed (N/A — behavior restored to intended)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extension loading compatibility across different runtime environments.
  * Added fallback handling for module loading when the primary loading method is unavailable.
  * Added validation to provide an error when the loaded extension does not expose the expected interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->