### PR TITLE
feat(safety): ordered bash command policy seam (#405 S1)

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -1467,6 +1467,38 @@ function loadRuntimeGuardrailsConfig(
 	}
 }
 
+/**
+ * Ordered policy seam for the model-initiated `bash` tool_call path
+ * (gentle-pi#405 work unit S1).
+ *
+ * `evaluateBashPolicies` runs these policies in list order and the first
+ * verdict (a non-undefined ToolCallEventResult) wins: a policy returning
+ * `undefined` allows the command to pass to the next policy, and an overall
+ * `undefined` means no policy objected. Future policies (package-manager,
+ * SQL) append entries here so evaluation order stays explicit and greppable
+ * through the stable `name` strings.
+ */
+interface BashCommandPolicy {
+	/** Stable, greppable identifier; tests pin the ordered list by name. */
+	name: string;
+	evaluate: (
+		command: string,
+		ctx: ExtensionContext,
+		events: ExtensionAPI["events"],
+		herdrLifecycle: HerdrConfirmationLifecycle,
+	) => Promise<ToolCallEventResult | undefined>;
+}
+
+const BASH_COMMAND_POLICIES: readonly BashCommandPolicy[] = [
+	{
+		name: "runtime-guardrails",
+		// Thin adapter preserving confirmCommand's async signature; the guard
+		// logic itself stays byte-identical inside confirmCommand.
+		evaluate: async (command, ctx, events, herdrLifecycle) =>
+			confirmCommand(command, ctx, events, herdrLifecycle),
+	},
+];
+
 const PATH_GUARDED_TOOL_NAMES = new Set(["read", "write", "edit"]);
 const PATH_INPUT_KEYS = new Set([
 	"path",
@@ -1857,6 +1889,28 @@ async function confirmCommand(
 		reason:
 			"Gentle AI safety policy blocked the command because it was not confirmed.",
 	};
+}
+
+/**
+ * Evaluate the ordered bash command policies for a model-initiated `bash`
+ * tool call. Policies run in `BASH_COMMAND_POLICIES` order; the first policy
+ * to return a verdict terminates evaluation with that verdict, while an
+ * `undefined` from a policy defers to the remaining policies. The optional
+ * `policies` argument exists for tests and future composition; production
+ * callers use the default ordered list.
+ */
+async function evaluateBashPolicies(
+	command: string,
+	ctx: ExtensionContext,
+	events: ExtensionAPI["events"],
+	herdrLifecycle: HerdrConfirmationLifecycle,
+	policies: readonly BashCommandPolicy[] = BASH_COMMAND_POLICIES,
+): Promise<ToolCallEventResult | undefined> {
+	for (const policy of policies) {
+		const verdict = await policy.evaluate(command, ctx, events, herdrLifecycle);
+		if (verdict !== undefined) return verdict;
+	}
+	return undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -7496,6 +7550,8 @@ export const __testing = {
 	guardedCommandPreview,
 	guardedCommandTitle,
 	loadRuntimeGuardrailsConfig,
+	BASH_COMMAND_POLICIES,
+	evaluateBashPolicies,
 	buildGentlePrompt,
 	nativeStatusUnsupported,
 	executeReviewControllerOperation,
@@ -8174,7 +8230,12 @@ function createGentleAiExtensionForTesting(
 		if (!isRecord(event.input) || typeof event.input.command !== "string") {
 			return undefined;
 		}
-		return await confirmCommand(event.input.command, ctx, pi.events, herdrLifecycle);
+			return await evaluateBashPolicies(
+				event.input.command,
+				ctx,
+				pi.events,
+				herdrLifecycle,
+			);
 	});
 
 	for (const owner of ["delegation", "review", "sdd"] as const) {

--- a/tests/autonomous-guard.test.ts
+++ b/tests/autonomous-guard.test.ts
@@ -650,3 +650,135 @@ test("loadRuntimeGuardrailsConfig: autonomousMode:{} (object) in JSON does NOT a
 		rmSync(dir, { recursive: true, force: true });
 	}
 });
+// evaluateBashPolicies — ordered bash command policy seam (gentle-pi#405 S1)
+// ---------------------------------------------------------------------------
+
+type BashPolicySeamArgs = Parameters<typeof __testing.evaluateBashPolicies>;
+
+function makeBashPolicySeamHarness(cwd: string) {
+	return {
+		ctx: { cwd, hasUI: false, ui: {} } as BashPolicySeamArgs[1],
+		events: { emit: () => {}, on: () => {} } as BashPolicySeamArgs[2],
+		herdrLifecycle: {
+			begin: () => {},
+			settle: () => {},
+		} as BashPolicySeamArgs[3],
+	};
+}
+
+function makeStubBashPolicy(
+	name: string,
+	verdict: { block: true; reason: string } | undefined,
+	calls: string[],
+): NonNullable<BashPolicySeamArgs[4]>[number] {
+	return {
+		name,
+		async evaluate(_command: string) {
+			calls.push(name);
+			return verdict;
+		},
+	};
+}
+
+test('evaluateBashPolicies: ordered policy list is exactly ["runtime-guardrails"]', () => {
+	assert.deepEqual(
+		__testing.BASH_COMMAND_POLICIES.map((policy) => policy.name),
+		["runtime-guardrails"],
+	);
+	assert.ok(
+		__testing.BASH_COMMAND_POLICIES.every(
+			(policy) => typeof policy.evaluate === "function",
+		),
+		"every policy must expose an evaluate function",
+	);
+});
+
+test("evaluateBashPolicies: short-circuits on the first verdict (later policies are not evaluated)", async () => {
+	const calls: string[] = [];
+	const firstVerdict = { block: true, reason: "first policy verdict" } as const;
+	const seam = makeBashPolicySeamHarness("/stub-cwd");
+	const result = await __testing.evaluateBashPolicies(
+		"ignored by stubs",
+		seam.ctx,
+		seam.events,
+		seam.herdrLifecycle,
+		[
+			makeStubBashPolicy("first", firstVerdict, calls),
+			makeStubBashPolicy(
+				"second",
+				{ block: true, reason: "second policy verdict" },
+				calls,
+			),
+		],
+	);
+	assert.deepEqual(result, firstVerdict);
+	assert.deepEqual(
+		calls,
+		["first"],
+		"the second policy must not run after a verdict",
+	);
+});
+
+test("evaluateBashPolicies: allow verdict from the last policy returns undefined overall", async () => {
+	const calls: string[] = [];
+	const seam = makeBashPolicySeamHarness("/stub-cwd");
+	const result = await __testing.evaluateBashPolicies(
+		"ignored by stubs",
+		seam.ctx,
+		seam.events,
+		seam.herdrLifecycle,
+		[
+			makeStubBashPolicy("first-allow", undefined, calls),
+			makeStubBashPolicy("last-allow", undefined, calls),
+		],
+	);
+	assert.equal(result, undefined);
+	assert.deepEqual(
+		calls,
+		["first-allow", "last-allow"],
+		"an allow must not short-circuit remaining policies",
+	);
+});
+
+test("evaluateBashPolicies: real runtime-guardrails policy blocks hard-deny commands through the seam", async () => {
+	const dir = makeTmpDir();
+	const originalConfigHome = process.env.GENTLE_PI_CONFIG_HOME;
+	process.env.GENTLE_PI_CONFIG_HOME = join(dir, "config-home");
+	try {
+		const seam = makeBashPolicySeamHarness(dir);
+		const result = await __testing.evaluateBashPolicies(
+			"rm -rf /",
+			seam.ctx,
+			seam.events,
+			seam.herdrLifecycle,
+		);
+		assert.equal(result?.block, true);
+		assert.match(result?.reason ?? "", /destructive/);
+	} finally {
+		if (originalConfigHome === undefined)
+			delete process.env.GENTLE_PI_CONFIG_HOME;
+		else process.env.GENTLE_PI_CONFIG_HOME = originalConfigHome;
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("evaluateBashPolicies: real runtime-guardrails policy allows a non-guarded command through the seam", async () => {
+	const dir = makeTmpDir();
+	const originalConfigHome = process.env.GENTLE_PI_CONFIG_HOME;
+	process.env.GENTLE_PI_CONFIG_HOME = join(dir, "config-home");
+	try {
+		const seam = makeBashPolicySeamHarness(dir);
+		const result = await __testing.evaluateBashPolicies(
+			"echo hello",
+			seam.ctx,
+			seam.events,
+			seam.herdrLifecycle,
+		);
+		assert.equal(result, undefined);
+	} finally {
+		if (originalConfigHome === undefined)
+			delete process.env.GENTLE_PI_CONFIG_HOME;
+		else process.env.GENTLE_PI_CONFIG_HOME = originalConfigHome;
+		rmSync(dir, { recursive: true, force: true });
+	}
+});

--- a/tests/autonomous-guard.test.ts
+++ b/tests/autonomous-guard.test.ts
@@ -658,7 +658,10 @@ type BashPolicySeamArgs = Parameters<typeof __testing.evaluateBashPolicies>;
 function makeBashPolicySeamHarness(cwd: string) {
 	return {
 		ctx: { cwd, hasUI: false, ui: {} } as BashPolicySeamArgs[1],
-		events: { emit: () => {}, on: () => {} } as BashPolicySeamArgs[2],
+		events: {
+			emit: (_channel: string, _data: unknown) => {},
+			on: (_channel: string, _handler: (data: unknown) => void) => () => {},
+		},
 		herdrLifecycle: {
 			begin: () => {},
 			settle: () => {},


### PR DESCRIPTION
Part of #405 (work unit S1 of 4; the issue stays open until S2-S4 land).

## Problem

#405 asks for structured, ordered evaluation of high-risk model-initiated Bash operations. Today the bash `tool_call` tail evaluates protections as an ordered if/else chain inside the single handler, which leaves no deterministic place to compose future policy modules (npm/pnpm package acquisition, destructive direct SQL) without duplicating authority or making precedence hard to reason about.

## What this adds

Unit S1 from the decomposition posted on the issue: a behavior-preserving evaluation seam.

- Restructures the model-initiated bash tool_call tail into an ordered, named policy list (`BASH_COMMAND_POLICIES`) evaluated by `evaluateBashPolicies`: first non-undefined verdict wins, `undefined` defers to the next policy, overall `undefined` allows.
- The only entry is the runtime-guardrails adapter over the byte-identical `confirmCommand`, so every verdict, block reason, emitted event sequence, headless fail-safe, and config precedence is unchanged.
- Exposed via `__testing` with order, short-circuit, and allow tests (`tests/autonomous-guard.test.ts`).

No new policy modules, no second authority, no sandbox semantics; S2 (npm/pnpm recognition), S3 (probes and evidence), and S4 (direct SQL DROP) build on this seam as separate chained units.

| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | Ordered policy list + `evaluateBashPolicies` + guardrails adapter (+63) |
| `tests/autonomous-guard.test.ts` | Seam order/short-circuit/allow tests (+132) |

## Verification

- `evaluateBashPolicies` seam tests: 5/5.
- Full `tests/autonomous-guard.test.ts`: 56/56.
- Full `tests/gentle-ai.test.ts` (integration, guards the unchanged-behavior claim): 36/36.
- Originally built 2026-09-09 with strict TDD; rebased today onto current `main` (127 commits, clean, no conflicts) with `git range-diff` reviewed and all suites re-run green.
- Native four-lens review could not start this round: the consent-gated START loops with instantly-expiring bindings (gentle-pi#748, recurrences documented there today, including the new tier-pattern data point). To be re-run once #748 is fixed; verification above is tests plus the rebase audit.

Label request: `type:feature` (pull-only author, maintainer needs to apply it).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Safety Improvements**
  - AI-initiated Bash commands now pass through an ordered safety evaluation before execution.
  - Destructive commands, such as `rm -rf /`, remain blocked or require confirmation, while safe commands such as `echo hello` can proceed.
  - Evaluation stops when a policy returns a blocking or confirmation decision.
  - Additional safety policies can be evaluated in sequence, with later checks still available when earlier policies allow the command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->